### PR TITLE
🐛 Align session-ended WebSocket teardown with the latest view's end clocks

### DIFF
--- a/packages/browser-rum-core/src/boot/startRum.spec.ts
+++ b/packages/browser-rum-core/src/boot/startRum.spec.ts
@@ -1,4 +1,4 @@
-import { ONE_SECOND, toServerDuration, relativeNow } from '@datadog/js-core/time'
+import { ONE_SECOND, toServerDuration, relativeNow, relativeToClocks } from '@datadog/js-core/time'
 import type { Duration } from '@datadog/js-core/time'
 import type { BufferedData, SessionManager } from '@datadog/browser-core'
 import {
@@ -64,6 +64,32 @@ function startRumStub(
   }
 }
 
+describe('session expiration lifecycle', () => {
+  it('notifies session expiration with clocks captured when the session expires', () => {
+    const clock = mockClock()
+    const sessionManager = createSessionManagerMock()
+    const notifySpy = spyOn(LifeCycle.prototype, 'notify').and.callThrough()
+    const { stop } = startRum(
+      mockRumConfiguration(),
+      sessionManager,
+      noopRecorderApi,
+      noopProfilerApi,
+      undefined,
+      createIdentityEncoder,
+      new BufferedObservable<BufferedData>(100),
+      createFakeTelemetryObject(),
+      createHooks()
+    )
+    registerCleanupTask(stop)
+
+    clock.tick(123)
+    const endClocks = relativeToClocks(relativeNow())
+    sessionManager.expire()
+
+    expect(notifySpy).toHaveBeenCalledWith(LifeCycleEventType.SESSION_EXPIRED, { endClocks })
+  })
+})
+
 describe('rum session', () => {
   let serverRumEvents: RumEvent[]
   let lifeCycle: LifeCycle
@@ -84,7 +110,7 @@ describe('rum session', () => {
     expect(serverRumEvents[0].type).toEqual('view')
     expect(serverRumEvents[0].session.id).toEqual('42')
 
-    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED, { endClocks: relativeToClocks(relativeNow()) })
     expect(serverRumEvents.length).toEqual(2)
 
     sessionManager.setId('43')

--- a/packages/browser-rum-core/src/boot/startRum.ts
+++ b/packages/browser-rum-core/src/boot/startRum.ts
@@ -76,7 +76,9 @@ export function startRum(
 
   lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, (event) => sendToExtension('rum', event))
 
-  sessionManager.expireObservable.subscribe(() => lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED))
+  sessionManager.expireObservable.subscribe(() =>
+    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED, { endClocks: clocksNow() })
+  )
   sessionManager.renewObservable.subscribe(() => lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED))
 
   const reportError = (message: string) => {

--- a/packages/browser-rum-core/src/domain/lifeCycle.ts
+++ b/packages/browser-rum-core/src/domain/lifeCycle.ts
@@ -10,6 +10,7 @@ import type { ViewEvent, ViewCreatedEvent, ViewEndedEvent, BeforeViewUpdateEvent
 import type { DurationVitalStart } from './vital/vitalCollection'
 import type { TrackedEventData } from './eventTracker'
 import type { ActionEventData } from './action/trackManualActions'
+import type { SessionExpiredEvent } from './session/session.types'
 
 export const enum LifeCycleEventType {
   // Contexts (like viewHistory) should be opened using prefixed BEFORE_XXX events and closed using prefixed AFTER_XXX events
@@ -93,7 +94,7 @@ export interface LifeCycleEventMap {
   [LifeCycleEventTypeAsConst.REQUEST_STARTED]: RequestStartEvent
   [LifeCycleEventTypeAsConst.REQUEST_COMPLETED]: RequestCompleteEvent
   [LifeCycleEventTypeAsConst.WEBSOCKET_COMPLETED]: WebSocketCompleteEvent
-  [LifeCycleEventTypeAsConst.SESSION_EXPIRED]: void
+  [LifeCycleEventTypeAsConst.SESSION_EXPIRED]: SessionExpiredEvent
   [LifeCycleEventTypeAsConst.SESSION_RENEWED]: void
   [LifeCycleEventTypeAsConst.PREPARE_URGENT_FLUSH]: UrgentFlushReason
   [LifeCycleEventTypeAsConst.RAW_RUM_EVENT_COLLECTED]: RawRumEventCollectedData

--- a/packages/browser-rum-core/src/domain/resource/webSocketCollection.spec.ts
+++ b/packages/browser-rum-core/src/domain/resource/webSocketCollection.spec.ts
@@ -36,6 +36,10 @@ describe('webSocketCollection', () => {
     })
   })
 
+  function expireSession(endClocks = relativeToClocks(clock.relative(0))) {
+    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED, { endClocks })
+  }
+
   function startTracking(
     viewHistory = mockViewHistory(),
     addDurationVital: (vital: DurationVital) => void = jasmine.createSpy()
@@ -498,8 +502,9 @@ describe('webSocketCollection', () => {
     it('emits a duration-0 vital at flush time on a session_end flush', () => {
       const addDurationVital = jasmine.createSpy<(vital: DurationVital) => void>()
       const tracker = startTracking(mockViewHistory(), addDurationVital)
+      const endClocks = relativeToClocks(clock.relative(40))
       notifyConnecting()
-      tracker.flushOpenConnections('session_end')
+      tracker.flushOpenConnections('session_end', endClocks)
 
       const connectingVital = addDurationVital.calls.argsFor(0)[0]
       const closedVital = addDurationVital.calls.argsFor(1)[0]
@@ -507,6 +512,7 @@ describe('webSocketCollection', () => {
       expect(closedVital.name).toBe(WEBSOCKET_CLOSED_VITAL_NAME)
       expect(closedVital.type).toBe(VitalType.DURATION)
       expect(closedVital.duration).toBe(0 as Duration)
+      expect(webSocketCompleteEvents[0].endClocks).toEqual(endClocks)
       expect(closedVital.startClocks).toEqual(webSocketCompleteEvents[0].endClocks)
       expect(closedVital.context).toEqual({
         url: webSocketCompleteEvents[0].url,
@@ -567,13 +573,15 @@ describe('webSocketCollection', () => {
     }
 
     it('finalizes open connections with tracking_end_reason="session_end" when the session expires', () => {
+      const endClocks = relativeToClocks(clock.relative(40))
       startCollection()
       notifyConnecting()
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession(endClocks)
 
       expect(webSocketCompleteEvents.length).toBe(1)
       expect(webSocketCompleteEvents[0].trackingEndReason).toBe('session_end')
+      expect(webSocketCompleteEvents[0].endClocks).toEqual(endClocks)
       expect(webSocketCompleteEvents[0].handshakeSucceeded).toBeFalse()
       expect(webSocketCompleteEvents[0].closeCode).toBeUndefined()
       expect(webSocketCompleteEvents[0].closeReason).toBeUndefined()
@@ -598,7 +606,7 @@ describe('webSocketCollection', () => {
       notifyOpen(10)
       notifyMessageOut(20, 10)
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession()
 
       expect(webSocketCompleteEvents.length).toBe(1)
       expect(webSocketCompleteEvents[0].trackingEndReason).toBe('session_end')

--- a/packages/browser-rum-core/src/domain/resource/webSocketCollection.ts
+++ b/packages/browser-rum-core/src/domain/resource/webSocketCollection.ts
@@ -58,7 +58,7 @@ interface WebSocketConnection {
 }
 
 export interface WebSocketConnectionTracker {
-  flushOpenConnections: (reason: WebSocketTrackingEndReason) => void
+  flushOpenConnections: (reason: WebSocketTrackingEndReason, endClocks?: ClocksState) => void
   stop: () => void
 }
 
@@ -72,8 +72,8 @@ export function startWebSocketCollection(
   // Session-boundary cleanup happens on SESSION_EXPIRED (fired before SESSION_RENEWED). Open
   // connections are finalized once with trackingEndReason "session_end"; later events on the same
   // WebSocket instance are ignored.
-  const sessionExpiredSubscription = lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, () => {
-    tracker.flushOpenConnections('session_end')
+  const sessionExpiredSubscription = lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, ({ endClocks }) => {
+    tracker.flushOpenConnections('session_end', endClocks)
   })
 
   return {
@@ -205,11 +205,9 @@ export function trackWebSocket(
   })
 
   return {
-    flushOpenConnections: (reason) => {
-      const at = clocksNow()
-
+    flushOpenConnections: (reason, endClocks = clocksNow()) => {
       webSocketRegistry.forEach((webSocket) => {
-        completeConnection(webSocket, { at }, reason)
+        completeConnection(webSocket, { at: endClocks }, reason)
       })
 
       webSocketRegistry.clear()

--- a/packages/browser-rum-core/src/domain/session/session.types.ts
+++ b/packages/browser-rum-core/src/domain/session/session.types.ts
@@ -1,0 +1,5 @@
+import type { ClocksState } from '@datadog/js-core/time'
+
+export interface SessionExpiredEvent {
+  endClocks: ClocksState
+}

--- a/packages/browser-rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/browser-rum-core/src/domain/view/trackViews.spec.ts
@@ -1,4 +1,4 @@
-import type { RelativeTime, Duration } from '@datadog/js-core/time'
+import type { RelativeTime, Duration, ClocksState } from '@datadog/js-core/time'
 import { timeStampNow, relativeToClocks, relativeNow } from '@datadog/js-core/time'
 import { PageExitReason, display } from '@datadog/browser-core'
 
@@ -16,6 +16,10 @@ import { SESSION_KEEP_ALIVE_INTERVAL, THROTTLE_VIEW_UPDATE_PERIOD, KEEP_TRACKING
 import type { ViewTest } from './setupViewTest.specHelper'
 import { setupViewTest } from './setupViewTest.specHelper'
 import { isLayoutShiftSupported } from './viewMetrics/trackCumulativeLayoutShift'
+
+function expireSession(lifeCycle: LifeCycle, endClocks: ClocksState = relativeToClocks(relativeNow())) {
+  lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED, { endClocks })
+}
 
 describe('track views automatically', () => {
   const lifeCycle = new LifeCycle()
@@ -167,9 +171,17 @@ describe('view lifecycle', () => {
 
       expect(getViewEndCount()).toBe(0)
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession(lifeCycle)
 
       expect(getViewEndCount()).toBe(1)
+    })
+
+    it('should end the view at the session expiration clocks', () => {
+      const endClocks = relativeToClocks(clock.relative(123))
+
+      expireSession(lifeCycle, endClocks)
+
+      expect(viewTest.getViewEnd(0).endClocks).toEqual(endClocks)
     })
 
     it('should send a final view update', () => {
@@ -177,7 +189,7 @@ describe('view lifecycle', () => {
 
       expect(getViewUpdateCount()).toBe(1)
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession(lifeCycle)
 
       expect(getViewUpdateCount()).toBe(2)
       expect(getViewUpdate(0).sessionIsActive).toBe(true)
@@ -189,7 +201,7 @@ describe('view lifecycle', () => {
 
       expect(getViewCreateCount()).toBe(1)
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession(lifeCycle)
 
       expect(getViewCreateCount()).toBe(1)
     })
@@ -199,12 +211,12 @@ describe('view lifecycle', () => {
 
       expect(getViewEndCount()).toBe(0)
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession(lifeCycle)
 
       expect(getViewEndCount()).toBe(1)
       expect(getViewUpdateCount()).toBe(2)
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession(lifeCycle)
 
       expect(getViewEndCount()).toBe(1)
       expect(getViewUpdateCount()).toBe(2)
@@ -217,7 +229,7 @@ describe('view lifecycle', () => {
 
       expect(getViewCreateCount()).toBe(1)
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession(lifeCycle)
       lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
       expect(getViewCreateCount()).toBe(2)
@@ -226,7 +238,7 @@ describe('view lifecycle', () => {
     it('should use session_renewal loading type for the new view', () => {
       const { getViewUpdate, getViewUpdateCount } = viewTest
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession(lifeCycle)
       lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
       expect(getViewUpdate(getViewUpdateCount() - 1).loadingType).toBe(ViewLoadingType.SESSION_RENEWAL)
@@ -234,17 +246,17 @@ describe('view lifecycle', () => {
 
     it('should use the current view name, service and version for the new view', () => {
       const { getViewCreateCount, getViewCreate, startView } = viewTest
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession(lifeCycle)
       lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
       startView({ name: 'view 1', service: 'service 1', version: 'version 1' })
       startView({ name: 'view 2', service: 'service 2', version: 'version 2' })
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession(lifeCycle)
       lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
       startView({ name: 'view 3', service: 'service 3', version: 'version 3' })
       changeLocation('/bar')
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession(lifeCycle)
       lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
       expect(getViewCreateCount()).toBe(8)
@@ -324,7 +336,7 @@ describe('view lifecycle', () => {
       const { getViewUpdateCount } = viewTest
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD) // make sure we don't have pending update
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession(lifeCycle)
 
       const previousViewUpdateCount = getViewUpdateCount()
 
@@ -769,7 +781,7 @@ describe('view custom timings', () => {
     clock.tick(0) // run immediate timeouts (mostly for `trackNavigationTimings`)
     const { getViewUpdateCount, addTiming } = viewTest
 
-    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    expireSession(lifeCycle)
 
     expect(getViewUpdateCount()).toBe(2)
 
@@ -829,7 +841,7 @@ describe('manual loading time', () => {
     clock.tick(0) // run immediate timeouts (mostly for `trackNavigationTimings`)
     const { getViewUpdateCount, setLoadingTime } = viewTest
 
-    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    expireSession(lifeCycle)
 
     const previousCount = getViewUpdateCount()
 

--- a/packages/browser-rum-core/src/domain/view/trackViews.ts
+++ b/packages/browser-rum-core/src/domain/view/trackViews.ts
@@ -154,8 +154,8 @@ export function trackViews(
       })
     })
 
-    lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, () => {
-      currentView.end({ sessionIsActive: false })
+    lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, ({ endClocks }) => {
+      currentView.end({ sessionIsActive: false, endClocks })
     })
   }
 

--- a/packages/browser-rum/src/boot/recorderApi.spec.ts
+++ b/packages/browser-rum/src/boot/recorderApi.spec.ts
@@ -9,6 +9,7 @@ import type {
 import { BridgeCapability, display, resetSampleDecisionCache } from '@datadog/browser-core'
 import type { RecorderApi } from '@datadog/browser-rum-core'
 import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
+import { clocksNow } from '@datadog/js-core/time'
 import type { MockTelemetry, SessionManagerMock } from '@datadog/browser-core/test'
 import {
   collectAsyncCalls,
@@ -40,6 +41,10 @@ describe('makeRecorderApi', () => {
   let createDeflateWorkerSpy: jasmine.Spy<CreateDeflateWorker>
   let rumInit: (options?: { worker?: DeflateWorker }) => void
   let telemetry: MockTelemetry
+
+  function expireSession() {
+    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED, { endClocks: clocksNow() })
+  }
 
   function setupRecorderApi({
     sessionManager,
@@ -370,7 +375,7 @@ describe('makeRecorderApi', () => {
         it('starts recording if startSessionReplayRecording was called', async () => {
           rumInit()
           sessionManager.setId(LOW_HASH_UUID)
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           expect(startRecordingSpy).not.toHaveBeenCalled()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           await collectAsyncCalls(startRecordingSpy, 1)
@@ -383,7 +388,7 @@ describe('makeRecorderApi', () => {
           rumInit()
           recorderApi.stop()
           sessionManager.setId(LOW_HASH_UUID)
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
           expect(importRecorderSpy).not.toHaveBeenCalled()
@@ -399,7 +404,7 @@ describe('makeRecorderApi', () => {
         it('keeps not recording if startSessionReplayRecording was called', () => {
           rumInit()
           sessionManager.setNotTracked()
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
           expect(importRecorderSpy).not.toHaveBeenCalled()
@@ -415,7 +420,7 @@ describe('makeRecorderApi', () => {
 
         it('keeps not recording if startSessionReplayRecording was called', () => {
           rumInit()
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
           expect(importRecorderSpy).not.toHaveBeenCalled()
@@ -435,7 +440,7 @@ describe('makeRecorderApi', () => {
 
           expect(startRecordingSpy).toHaveBeenCalledTimes(1)
           sessionManager.setId(HIGH_HASH_UUID)
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           expect(stopRecordingSpy).toHaveBeenCalled()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           expect(importRecorderSpy).toHaveBeenCalledTimes(1)
@@ -446,7 +451,7 @@ describe('makeRecorderApi', () => {
           const { triggerOnDomLoaded } = mockDocumentReadyState()
           rumInit()
           sessionManager.setId(HIGH_HASH_UUID)
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           triggerOnDomLoaded()
           expect(importRecorderSpy).toHaveBeenCalled()
@@ -464,7 +469,7 @@ describe('makeRecorderApi', () => {
           await collectAsyncCalls(startRecordingSpy, 1)
           expect(startRecordingSpy).toHaveBeenCalledTimes(1)
           sessionManager.setNotTracked()
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           expect(stopRecordingSpy).toHaveBeenCalled()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           expect(importRecorderSpy).toHaveBeenCalledTimes(1)
@@ -481,7 +486,7 @@ describe('makeRecorderApi', () => {
           rumInit()
           await collectAsyncCalls(startRecordingSpy, 1)
           expect(startRecordingSpy).toHaveBeenCalledTimes(1)
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           expect(stopRecordingSpy).toHaveBeenCalled()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           await collectAsyncCalls(startRecordingSpy, 2)
@@ -496,7 +501,7 @@ describe('makeRecorderApi', () => {
           expect(startRecordingSpy).toHaveBeenCalledTimes(1)
           recorderApi.stop()
           expect(stopRecordingSpy).toHaveBeenCalledTimes(1)
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           expect(importRecorderSpy).toHaveBeenCalledTimes(1)
           expect(startRecordingSpy).toHaveBeenCalledTimes(1)
@@ -513,7 +518,7 @@ describe('makeRecorderApi', () => {
         it('starts recording if startSessionReplayRecording was called', async () => {
           rumInit()
           sessionManager.setTracked()
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           await collectAsyncCalls(startRecordingSpy, 1)
 
@@ -525,7 +530,7 @@ describe('makeRecorderApi', () => {
           rumInit()
           recorderApi.stop()
           sessionManager.setTracked()
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           expect(importRecorderSpy).not.toHaveBeenCalled()
           expect(startRecordingSpy).not.toHaveBeenCalled()
@@ -543,7 +548,7 @@ describe('makeRecorderApi', () => {
           rumInit()
           sessionManager.setTracked()
           sessionManager.setId(HIGH_HASH_UUID)
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           expect(importRecorderSpy).not.toHaveBeenCalled()
           expect(startRecordingSpy).not.toHaveBeenCalled()
@@ -559,7 +564,7 @@ describe('makeRecorderApi', () => {
 
         it('keeps not recording if startSessionReplayRecording was called', () => {
           rumInit()
-          lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+          expireSession()
           lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           expect(importRecorderSpy).not.toHaveBeenCalled()
           expect(startRecordingSpy).not.toHaveBeenCalled()

--- a/packages/browser-rum/src/domain/profiling/datadogProfiler.spec.ts
+++ b/packages/browser-rum/src/domain/profiling/datadogProfiler.spec.ts
@@ -70,6 +70,10 @@ describe('profiler', () => {
 
   let lifeCycle = new LifeCycle()
 
+  function expireSession() {
+    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED, { endClocks: clocksNow() })
+  }
+
   function setupProfiler(
     currentView?: ViewHistoryEntry,
     profilerConfigOverrides?: Partial<RUMProfilerConfiguration>,
@@ -766,7 +770,7 @@ describe('profiler', () => {
     expect(profilingContextManager.get()?.status).toBe('running')
 
     // Notify that the session has expired (sync - state changes immediately)
-    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    expireSession()
 
     expect(profiler.isStopped()).toBe(true)
     expect(profilingContextManager.get()?.status).toBe('stopped')
@@ -789,7 +793,7 @@ describe('profiler', () => {
     expect(profilingContextManager.get()?.status).toBe('running')
 
     // Notify that the session has expired (sync - state changes immediately)
-    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    expireSession()
 
     expect(profiler.isStopped()).toBe(true)
     expect(profilingContextManager.get()?.status).toBe('stopped')
@@ -818,7 +822,7 @@ describe('profiler', () => {
     expect(profilingContextManager.get()?.status).toBe('running')
 
     // Notify that the session has expired (sync - state changes immediately)
-    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    expireSession()
 
     expect(profiler.isStopped()).toBe(true)
     expect(profilingContextManager.get()?.status).toBe('stopped')
@@ -860,7 +864,7 @@ describe('profiler', () => {
     expect(profilingContextManager.get()?.status).toBe('running')
 
     // First cycle: expire and renew (sync - state changes immediately)
-    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    expireSession()
     expect(profiler.isStopped()).toBe(true)
     expect(profilingContextManager.get()?.status).toBe('stopped')
 
@@ -872,7 +876,7 @@ describe('profiler', () => {
     expect(profilingContextManager.get()?.status).toBe('running')
 
     // Second cycle: expire and renew again (sync)
-    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    expireSession()
     expect(profiler.isStopped()).toBe(true)
     expect(profilingContextManager.get()?.status).toBe('stopped')
 
@@ -932,7 +936,7 @@ describe('profiler', () => {
     // Session expires while profiler is running
     // With sync state changes, the profiler state becomes 'stopped' immediately
     // while data collection continues in the background (fire-and-forget)
-    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    expireSession()
 
     // State is immediately 'stopped' (sync), even though data collection is async
     expect(profiler.isStopped()).toBe(true)
@@ -965,7 +969,7 @@ describe('profiler', () => {
     expect(profilingContextManager.get()?.status).toBe('running')
 
     // Session expires (sync - state changes immediately)
-    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    expireSession()
 
     expect(profiler.isStopped()).toBe(true)
     expect(profilingContextManager.get()?.status).toBe('stopped')
@@ -1006,7 +1010,7 @@ describe('profiler', () => {
     await waitForBoolean(() => profiler.isRunning())
 
     // Session expires
-    testLifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    testLifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED, { endClocks: clocksNow() })
     expect(profiler.isStopped()).toBeTrue()
 
     // Session renews with HIGH_HASH_UUID, which is not sampled at profilingSampleRate: 50
@@ -1164,7 +1168,7 @@ describe('profiler', () => {
     await waitForBoolean(() => profiler.isPaused())
 
     // Session expires while profiler is paused (sync - state changes immediately)
-    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    expireSession()
 
     expect(profiler.isStopped()).toBe(true)
     expect(profilingContextManager.get()?.status).toBe('stopped')
@@ -1303,7 +1307,7 @@ describe('profiler', () => {
       profiler.start()
       await waitForBoolean(() => profiler.isRunning())
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession()
       expect(profiler.isStopped()).toBe(true)
 
       resolveQuota({ decision: 'quota_ko', reason: 'quota_exceeded' })
@@ -1365,7 +1369,7 @@ describe('profiler', () => {
       profiler.start()
       await waitForBoolean(() => profiler.isRunning())
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      expireSession()
       lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
       await waitForBoolean(() => profiler.isRunning())
 

--- a/test/e2e/scenario/rum/websockets.scenario.ts
+++ b/test/e2e/scenario/rum/websockets.scenario.ts
@@ -19,6 +19,8 @@ type RumResourceEventWithWebSocket = RumResourceEvent & {
   }
 }
 
+const NANOSECONDS_PER_MILLISECOND = 1e6
+
 test.describe('rum websockets', () => {
   createTest('collect websocket vitals and websocket resource when the connection closes')
     .withRum({ enableExperimentalFeatures: ['track_websockets'] })
@@ -72,7 +74,7 @@ test.describe('rum websockets', () => {
       expect(rumEvent!.resource.websocket.tracking_end_reason).toBe('close_event')
     })
 
-  createTest('websocket resource is reported with session_end when the session expires')
+  createTest('collects the websocket-closed vital when the session expires')
     .withRum({ enableExperimentalFeatures: ['track_websockets'] })
     .withBody(WebSocketPage.testBody())
     .run(async ({ intakeRegistry, flushEvents, page, browserContext }) => {
@@ -87,6 +89,21 @@ test.describe('rum websockets', () => {
         (e) => e.resource.websocket.tracking_end_reason === 'session_end'
       )
       expect(wsWithSessionEnd).toBeDefined()
+
+      const closedVital = intakeRegistry.rumVitalEvents.find((e) => e.vital.name === 'websocket-closed')
+      expect(closedVital).toBeDefined()
+      expect(closedVital!.context!.connection_id).toBe(wsWithSessionEnd!.resource.websocket.connection_id)
+      expect(closedVital!.date).toBe(wsWithSessionEnd!.resource.websocket.end_time)
+      expect(closedVital!.session.id).toBe(wsWithSessionEnd!.session.id)
+      expect(closedVital!.view.id).toBe(wsWithSessionEnd!.resource.websocket.end_view_id)
+      expect(closedVital!.view.url).toBe(wsWithSessionEnd!.view.url)
+
+      const associatedView = intakeRegistry.rumViewEvents.find((event) => event.view.id === closedVital!.view.id)
+      expect(associatedView).toBeDefined()
+
+      const viewEndTime = associatedView!.date + associatedView!.view.time_spent / NANOSECONDS_PER_MILLISECOND
+      expect(closedVital!.date).toBeLessThanOrEqual(viewEndTime)
+      expect(wsWithSessionEnd!.resource.websocket.end_time).toBeLessThanOrEqual(viewEndTime)
     })
 
   createTest(


### PR DESCRIPTION
## Motivation

When a RUM session expires, open WebSocket connections are finalized with `tracking_end_reason: 'session_end'`. The teardown used `clocksNow()` independently in both `trackViews` (to end the active view) and `webSocketCollection` (to close the websocket vital/resource). Because these two calls happened at slightly different times, the websocket's `end_time` could land **after** the view's `end_time` — causing the `websocket-closed` vital to be dropped during assembly and the resource's `end_time` to fall outside the lifespan of the view it was attached to.

## Changes

- Add a `SessionExpiredEvent` type (`{ endClocks: ClocksState }`) carried on the `SESSION_EXPIRED` lifecycle event, instead of `void`.
- `startRum` now captures `clocksNow()` once when the session expires and notifies `SESSION_EXPIRED` with those clocks, so every subscriber ends things at the exact same instant.
- `trackViews` ends the current view using the shared `endClocks` from `SESSION_EXPIRED` instead of computing its own.
- `webSocketCollection.flushOpenConnections` now accepts an optional `endClocks` param, using the shared clocks passed on `SESSION_EXPIRED` (falling back to `clocksNow()` for its own `stop()` call, where no shared clocks exist).
- Unit tests covering the new `SessionExpiredEvent` payload and the wired session-end path in `startRum`, `trackViews`, and `webSocketCollection`.
- E2E test (renamed to "collects the websocket-closed vital when the session expires") asserting the `websocket-closed` vital and resource `end_time` do not exceed the associated view's end time.

## Test instructions

```bash
yarn test:unit --spec packages/browser-rum-core/src/boot/startRum.spec.ts
yarn test:unit --spec packages/browser-rum-core/src/domain/view/trackViews.spec.ts
yarn test:unit --spec packages/browser-rum-core/src/domain/resource/webSocketCollection.spec.ts
yarn build:apps && yarn test:e2e -g "collects the websocket-closed vital when the session expires"
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
