### PR TITLE
✨ [FFL-2858] Feature Flags tab — catalog browsing (stacked PR 2 of 3)

### DIFF
--- a/developer-extension/src/panel/components/tabs/flagsTab/flagCatalog.spec.ts
+++ b/developer-extension/src/panel/components/tabs/flagsTab/flagCatalog.spec.ts
@@ -1,0 +1,202 @@
+import type { CatalogFlag, FlagCatalogRequest } from './flagCatalog'
+import { fetchFlagCatalog } from './flagCatalog'
+
+describe('flagCatalog', () => {
+  describe('fetchFlagCatalog', () => {
+    const baseRequest: FlagCatalogRequest = { page: 1, pageSize: 20, search: '', typeFilter: [], tagFilter: [] }
+
+    function mockResponse(body: unknown) {
+      return spyOn(globalThis, 'fetch').and.returnValue(Promise.resolve(new Response(JSON.stringify(body))))
+    }
+
+    it('requests one page server-side (active-only, offset from page) and returns the server total', async () => {
+      const sampleFlag: CatalogFlag = {
+        key: 'flag-a',
+        name: 'Flag A',
+        type: 'BOOLEAN',
+        variants: [{ name: 'on', value: true }],
+        tags: ['x'],
+      }
+      const sampleTotal = 42
+      const spy = mockResponse({
+        data: [
+          {
+            attributes: {
+              key: sampleFlag.key,
+              name: sampleFlag.name,
+              value_type: sampleFlag.type,
+              // The API returns variant values as strings; parseVariantValue turns them back.
+              variants: sampleFlag.variants.map(({ name, value }) => ({ name, value: String(value) })),
+              tags: sampleFlag.tags,
+            },
+          },
+        ],
+        meta: { page: { total: sampleTotal } },
+      })
+
+      const page = await fetchFlagCatalog('tok', 'datad0g.com', { ...baseRequest, page: 3, pageSize: 20 })
+
+      const [requestUrl, requestInit] = spy.calls.argsFor(0) as [string, RequestInit]
+      const url = new URL(requestUrl)
+      expect(url.pathname).toBe('/api/ui/ffe/feature-flags')
+      expect(url.searchParams.get('page[limit]')).toBe('20')
+      expect(url.searchParams.get('page[offset]')).toBe('40') // (3 - 1) * 20
+      expect(url.searchParams.get('is_archived')).toBe('false')
+      expect((requestInit.headers as Record<string, string>).Authorization).toBe('Bearer tok')
+      expect(page.total).toBe(sampleTotal)
+      expect(page.flags).toEqual([sampleFlag])
+    })
+
+    it('sends search, value_type (repeated), and tags (repeated) as server-side filters', async () => {
+      const spy = mockResponse({ data: [], meta: { page: { total: 0 } } })
+
+      await fetchFlagCatalog('tok', 'datad0g.com', {
+        page: 1,
+        pageSize: 20,
+        search: 'checkout',
+        typeFilter: ['BOOLEAN', 'STRING'],
+        tagFilter: ['team:x', 'beta'],
+      })
+
+      const [requestUrl] = spy.calls.argsFor(0) as [string, RequestInit]
+      const url = new URL(requestUrl)
+      expect(url.searchParams.get('search')).toBe('checkout')
+      expect(url.searchParams.getAll('value_type')).toEqual(['BOOLEAN', 'STRING'])
+      expect(url.searchParams.getAll('tags')).toEqual(['team:x', 'beta'])
+    })
+
+    it('omits the search param when the term is empty', async () => {
+      const spy = mockResponse({ data: [], meta: { page: { total: 0 } } })
+      await fetchFlagCatalog('tok', 'datad0g.com', baseRequest)
+      const [requestUrl] = spy.calls.argsFor(0) as [string, RequestInit]
+      expect(new URL(requestUrl).searchParams.has('search')).toBe(false)
+    })
+
+    it('parses variant values by declared type, falling back to the raw string on bad input', async () => {
+      mockResponse({
+        data: [
+          {
+            attributes: {
+              key: 'f',
+              value_type: 'JSON',
+              variants: [
+                { name: 'ok', value: '{"a":1}' },
+                { name: 'bad', value: 'not json' },
+              ],
+            },
+          },
+          {
+            attributes: {
+              key: 'n',
+              value_type: 'INTEGER',
+              variants: [
+                { name: 'five', value: '5' },
+                { name: 'nan', value: 'abc' },
+              ],
+            },
+          },
+        ],
+        meta: { page: { total: 2 } },
+      })
+
+      const { flags } = await fetchFlagCatalog('tok', 'datad0g.com', baseRequest)
+      expect(flags[0].variants[0].value).toEqual({ a: 1 })
+      expect(flags[0].variants[1].value).toBe('not json')
+      expect(flags[1].variants[0].value).toBe(5)
+      expect(flags[1].variants[1].value).toBe('abc')
+    })
+
+    it('keeps malformed or out-of-range variant values raw instead of coercing them', async () => {
+      mockResponse({
+        data: [
+          {
+            attributes: {
+              key: 'b',
+              value_type: 'BOOLEAN',
+              variants: [
+                { name: 't', value: 'true' },
+                { name: 'f', value: 'false' },
+                { name: 'weird', value: 'True' },
+              ],
+            },
+          },
+          {
+            attributes: {
+              key: 'i',
+              value_type: 'INTEGER',
+              variants: [
+                { name: 'partial', value: '5abc' },
+                { name: 'float', value: '5.5' },
+                { name: 'unsafe', value: '9007199254740993' },
+              ],
+            },
+          },
+          {
+            attributes: {
+              key: 'd',
+              value_type: 'NUMERIC',
+              variants: [
+                { name: 'ok', value: '5.5' },
+                { name: 'partial', value: '5abc' },
+                { name: 'empty', value: '' },
+              ],
+            },
+          },
+        ],
+        meta: { page: { total: 3 } },
+      })
+
+      const { flags } = await fetchFlagCatalog('tok', 'datad0g.com', baseRequest)
+      const [booleanFlag, integer, numeric] = flags
+      expect(booleanFlag.variants.map((variant) => variant.value)).toEqual([true, false, 'True'])
+      expect(integer.variants.map((variant) => variant.value)).toEqual(['5abc', '5.5', '9007199254740993'])
+      expect(numeric.variants.map((variant) => variant.value)).toEqual([5.5, '5abc', ''])
+    })
+
+    it('dedupes flags sharing a key within a page, keeping the first occurrence', async () => {
+      mockResponse({
+        data: [
+          { attributes: { key: 'dup', name: 'First', value_type: 'STRING', variants: [], tags: [] } },
+          { attributes: { key: 'dup', name: 'Second', value_type: 'STRING', variants: [], tags: [] } },
+        ],
+        meta: { page: { total: 2 } },
+      })
+
+      const { flags } = await fetchFlagCatalog('tok', 'datad0g.com', baseRequest)
+      expect(flags.length).toBe(1)
+      expect(flags[0].name).toBe('First')
+    })
+
+    it('falls back to the key for a missing name and defaults tags/variants', async () => {
+      mockResponse({ data: [{ attributes: { key: 'no-name', value_type: 'STRING' } }], meta: { page: { total: 1 } } })
+
+      const { flags } = await fetchFlagCatalog('tok', 'datad0g.com', baseRequest)
+      expect(flags[0].name).toBe('no-name')
+      expect(flags[0].tags).toEqual([])
+      expect(flags[0].variants).toEqual([])
+    })
+
+    it('tolerates a response that omits data/meta, falling total back to the page length', async () => {
+      mockResponse({ errors: ['x'] })
+      const page = await fetchFlagCatalog('tok', 'datad0g.com', baseRequest)
+      expect(page.flags).toEqual([])
+      expect(page.total).toBe(0)
+    })
+
+    it('falls back total to the number of returned flags when meta.page.total is missing', async () => {
+      mockResponse({
+        data: [{ attributes: { key: 'a', value_type: 'STRING' } }, { attributes: { key: 'b', value_type: 'STRING' } }],
+      })
+      expect((await fetchFlagCatalog('tok', 'datad0g.com', baseRequest)).total).toBe(2)
+    })
+
+    it('throws on a non-ok response', async () => {
+      spyOn(globalThis, 'fetch').and.returnValue(
+        Promise.resolve(new Response('err', { status: 500, statusText: 'Server Error' }))
+      )
+      await expectAsync(fetchFlagCatalog('tok', 'datad0g.com', baseRequest)).toBeRejectedWithError(
+        /Failed to fetch flag catalog/
+      )
+    })
+  })
+})

--- a/developer-extension/src/panel/components/tabs/flagsTab/flagCatalog.ts
+++ b/developer-extension/src/panel/components/tabs/flagsTab/flagCatalog.ts
@@ -1,0 +1,154 @@
+import type { FlagType } from './flagTypeConstants'
+import { getFlagsApiHost } from './oauth'
+
+export interface CatalogFlag {
+  key: string
+  name: string
+  type: FlagType
+  // Parsed value of each variant (any JSON value); see parseVariantValue.
+  variants: Array<{ name: string; value: unknown }>
+  tags: string[]
+}
+
+// Filters + pagination sent to the server so the FFE endpoint does the work — the extension never
+// loads the whole catalog. The endpoint applies all of these itself: `search` matches name/key/tags,
+// `tags` are AND-ed, `value_type` is OR-ed (see dd-source ffe-service). `page` is 1-based.
+export interface FlagCatalogRequest {
+  page: number
+  pageSize: number
+  search: string
+  typeFilter: string[]
+  tagFilter: string[]
+}
+
+// One page of results plus the server's total count (for pagination).
+export interface FlagCatalogPage {
+  flags: CatalogFlag[]
+  total: number
+}
+
+interface RawFeatureFlag {
+  attributes: {
+    key: string
+    name?: string
+    value_type: FlagType
+    variants?: Array<{ name: string; value: string }>
+    tags?: string[]
+  }
+}
+
+interface RawFeatureFlagsResponse {
+  data?: RawFeatureFlag[]
+  meta?: { page?: { total?: number } }
+}
+
+// Variant values come back from the API as strings regardless of the flag's declared type. Falls
+// back to the raw string on unparseable input so one malformed variant can't blow up the mapping
+// of the entire catalog.
+function parseVariantValue(type: FlagType, rawValue: string): unknown {
+  switch (type) {
+    case 'BOOLEAN':
+      // Only the exact strings count; anything else (e.g. "True", "falsex", "") is malformed and
+      // kept raw rather than silently collapsing to false.
+      if (rawValue === 'true') {
+        return true
+      }
+      if (rawValue === 'false') {
+        return false
+      }
+      return rawValue
+    case 'INTEGER': {
+      // parseInt would accept partial/oversized input ("5abc" -> 5, unsafe integers get rounded), so
+      // require the whole string to be an integer within the safe range; otherwise keep it raw.
+      const parsed = Number(rawValue)
+      return /^[+-]?\d+$/.test(rawValue) && Number.isSafeInteger(parsed) ? parsed : rawValue
+    }
+    case 'NUMERIC': {
+      // parseFloat accepts a numeric prefix ("5abc" -> 5) and Number("") is 0, so require a
+      // non-empty string that parses fully to a finite number; otherwise keep it raw.
+      const parsed = Number(rawValue)
+      return rawValue.trim() !== '' && Number.isFinite(parsed) ? parsed : rawValue
+    }
+    case 'JSON':
+      try {
+        return JSON.parse(rawValue) as unknown
+      } catch {
+        return rawValue
+      }
+    case 'STRING':
+      return rawValue
+    default:
+      // The server returned a value_type outside the known union (which is a compile-time
+      // assumption, not a runtime guarantee) — keep the raw string rather than returning undefined,
+      // consistent with never letting one odd variant blow up the mapping.
+      return rawValue
+  }
+}
+
+/**
+ * Fetches ONE page of the flag catalog via the FFE UI endpoint (GET /api/ui/ffe/feature-flags),
+ * letting the server apply the filters + pagination. Returns the page's flags plus the server's
+ * total match count (`meta.page.total`) so the caller can render pagination. OAuth is the only
+ * supported auth path (see oauth.ts).
+ */
+export async function fetchFlagCatalog(
+  token: string,
+  site: string,
+  request: FlagCatalogRequest
+): Promise<FlagCatalogPage> {
+  const url = new URL(`https://${getFlagsApiHost(site)}/api/ui/ffe/feature-flags`)
+  url.searchParams.set('page[limit]', String(request.pageSize))
+  url.searchParams.set('page[offset]', String((request.page - 1) * request.pageSize))
+  // Active flags only: with archived included, an archived and an active flag can share a key and
+  // land on the same page, which would render as duplicate rows and collide React keys.
+  url.searchParams.set('is_archived', 'false')
+  if (request.search) {
+    url.searchParams.set('search', request.search)
+  }
+  for (const type of request.typeFilter) {
+    url.searchParams.append('value_type', type)
+  }
+  for (const tag of request.tagFilter) {
+    url.searchParams.append('tags', tag)
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to fetch flag catalog: ${response.status} ${response.statusText}`)
+  }
+
+  const body = (await response.json()) as RawFeatureFlagsResponse
+  // Tolerate a response that omits/mistypes `data` rather than throwing on `.map`.
+  const resources = Array.isArray(body?.data) ? body.data : []
+  return {
+    flags: mapResources(resources),
+    // Fall back to the page length when the server omits the total (e.g. a partial/legacy response).
+    total: body?.meta?.page?.total ?? resources.length,
+  }
+}
+
+function mapResources(resources: RawFeatureFlag[]): CatalogFlag[] {
+  // Dedupe by key as a cheap safety net against a flag appearing twice on a page (see is_archived
+  // note above); collisions would otherwise break React keys (`key={flag.key}`). Keep the first.
+  const byKey = new Map<string, CatalogFlag>()
+  for (const { attributes } of resources) {
+    if (byKey.has(attributes.key)) {
+      continue
+    }
+    byKey.set(attributes.key, {
+      key: attributes.key,
+      name: attributes.name || attributes.key,
+      type: attributes.value_type,
+      variants: (attributes.variants ?? []).map((variant) => ({
+        name: variant.name,
+        value: parseVariantValue(attributes.value_type, variant.value),
+      })),
+      tags: attributes.tags ?? [],
+    })
+  }
+  return Array.from(byKey.values())
+}

--- a/developer-extension/src/panel/components/tabs/flagsTab/flagCatalogList.tsx
+++ b/developer-extension/src/panel/components/tabs/flagsTab/flagCatalogList.tsx
@@ -1,0 +1,109 @@
+import { ActionIcon, Badge, Box, Code, CopyButton, Group, Loader, Space, Text, Tooltip } from '@mantine/core'
+import { IconCopy } from '@tabler/icons-react'
+import React from 'react'
+import type { CatalogFlag } from './flagCatalog'
+import type { FlagCatalogState } from './useFlagCatalog'
+
+export function FlagCatalogBody({
+  catalog,
+  flags,
+  total,
+}: {
+  catalog: FlagCatalogState
+  flags: CatalogFlag[]
+  total: number
+}) {
+  if (catalog.loading) {
+    return (
+      <Group justify="center" py="xl">
+        <Loader size="sm" />
+      </Group>
+    )
+  }
+
+  if (catalog.error) {
+    return <Text c="red">Failed to load catalog: {catalog.error}</Text>
+  }
+
+  return (
+    <>
+      <Text c="dimmed" size="xs">
+        {total} {total === 1 ? 'flag' : 'flags'}
+      </Text>
+      <Space h="xs" />
+      <Box style={{ border: '1px solid var(--mantine-color-gray-2)', borderRadius: 'var(--mantine-radius-sm)' }}>
+        {flags.length === 0 ? (
+          <Text c="dimmed" p="md">
+            No flags match.
+          </Text>
+        ) : (
+          flags.map((flag) => <FlagRow key={flag.key} flag={flag} />)
+        )}
+      </Box>
+    </>
+  )
+}
+
+function FlagRow({ flag }: { flag: CatalogFlag }) {
+  return (
+    <Group
+      justify="space-between"
+      wrap="nowrap"
+      align="center"
+      px="sm"
+      py="xs"
+      style={{ borderBottom: '1px solid var(--mantine-color-gray-1)' }}
+    >
+      <Box style={{ minWidth: 0, flex: 1 }}>
+        <Text size="sm" fw={600} truncate>
+          {flag.name}
+        </Text>
+        <FlagKey value={flag.key} />
+      </Box>
+      <Group gap="xs" wrap="wrap" justify="flex-end" style={{ flexShrink: 0, maxWidth: '55%' }}>
+        {flag.variants.length === 0 ? (
+          <Text c="dimmed" size="xs">
+            no variants
+          </Text>
+        ) : (
+          flag.variants.map((variant) => (
+            <Badge key={variant.name} variant="light" color="gray" title={formatValue(variant.value)}>
+              {variant.name}
+            </Badge>
+          ))
+        )}
+      </Group>
+    </Group>
+  )
+}
+
+function FlagKey({ value }: { value: string }) {
+  return (
+    <Group gap={4} wrap="nowrap" style={{ minWidth: 0 }}>
+      <Code
+        style={{
+          flex: '0 1 auto',
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {value}
+      </Code>
+      <CopyButton value={value}>
+        {({ copied, copy }) => (
+          <Tooltip label={copied ? 'Copied' : 'Copy key'} withArrow>
+            <ActionIcon size="xs" variant="subtle" color="gray" onClick={copy} style={{ flexShrink: 0 }}>
+              <IconCopy size={12} />
+            </ActionIcon>
+          </Tooltip>
+        )}
+      </CopyButton>
+    </Group>
+  )
+}
+
+function formatValue(value: unknown): string {
+  return typeof value === 'string' ? value : JSON.stringify(value)
+}

--- a/developer-extension/src/panel/components/tabs/flagsTab/flagFilterBar.tsx
+++ b/developer-extension/src/panel/components/tabs/flagsTab/flagFilterBar.tsx
@@ -1,0 +1,47 @@
+import { Group, MultiSelect, Stack, TagsInput, TextInput } from '@mantine/core'
+import { IconSearch } from '@tabler/icons-react'
+import React from 'react'
+import { FLAG_TYPES, TYPE_LABELS } from './flagTypeConstants'
+import type { FlagCatalogView } from './useFlagCatalogView'
+
+// Type is a fixed set, so its options are static. There's no tags endpoint and we only load a page
+// at a time, so the Tag filter can't show every tag — instead it offers `tagSuggestions` (tags seen
+// on pages loaded so far) as autocomplete while still accepting any typed tag. Search/type/tags are
+// all applied server-side (see useFlagCatalog).
+export function FlagFilterBar({ view, tagSuggestions }: { view: FlagCatalogView; tagSuggestions: string[] }) {
+  const typeOptions = FLAG_TYPES.map((type) => ({ value: type, label: TYPE_LABELS[type] }))
+
+  return (
+    <Stack gap="xs">
+      <TextInput
+        placeholder="Filter your feature flags"
+        leftSection={<IconSearch size={14} />}
+        value={view.search}
+        onChange={(event) => view.setSearch(event.currentTarget.value)}
+        size="xs"
+      />
+      <Group gap="xs" wrap="wrap" align="flex-end">
+        <MultiSelect
+          label="Type"
+          placeholder={view.typeFilter.length === 0 ? 'All' : undefined}
+          data={typeOptions}
+          value={view.typeFilter}
+          onChange={view.setTypeFilter}
+          size="xs"
+          w={220}
+          clearable
+        />
+        <TagsInput
+          label="Tags"
+          placeholder={view.tagFilter.length === 0 ? 'Type or pick a tag…' : undefined}
+          data={tagSuggestions}
+          value={view.tagFilter}
+          onChange={view.setTagFilter}
+          size="xs"
+          w={280}
+          clearable
+        />
+      </Group>
+    </Stack>
+  )
+}

--- a/developer-extension/src/panel/components/tabs/flagsTab/flagTypeConstants.ts
+++ b/developer-extension/src/panel/components/tabs/flagsTab/flagTypeConstants.ts
@@ -1,0 +1,14 @@
+// Feature-flag value types, in display order (drives the catalog's Type filter).
+export const FLAG_TYPES = ['BOOLEAN', 'STRING', 'INTEGER', 'NUMERIC', 'JSON'] as const
+
+// The value type of a feature flag, derived from FLAG_TYPES so the list stays the single source.
+export type FlagType = (typeof FLAG_TYPES)[number]
+
+// Display labels matching the webapp's Type filter (NUMERIC shows as "Number").
+export const TYPE_LABELS = {
+  BOOLEAN: 'Boolean',
+  STRING: 'String',
+  INTEGER: 'Integer',
+  NUMERIC: 'Number',
+  JSON: 'JSON',
+} satisfies Record<FlagType, string>

--- a/developer-extension/src/panel/components/tabs/flagsTab/flagsTab.tsx
+++ b/developer-extension/src/panel/components/tabs/flagsTab/flagsTab.tsx
@@ -1,14 +1,18 @@
-import { Box } from '@mantine/core'
-import React from 'react'
+import { Box, Group, Pagination, Space } from '@mantine/core'
+import React, { useEffect, useState } from 'react'
 import { TabBase } from '../../tabBase'
+import { useFlagCatalog } from './useFlagCatalog'
+import { useFlagCatalogView } from './useFlagCatalogView'
+import type { FlagAuthState } from './useFlagAuth'
 import { useFlagAuth } from './useFlagAuth'
 import { ConnectScreen, ConnectionHeader } from './connectScreen'
+import { FlagCatalogBody } from './flagCatalogList'
+import { FlagFilterBar } from './flagFilterBar'
 
 export function FlagsTab() {
   const auth = useFlagAuth()
 
-  // Gate the whole tab: nothing shows until the user connects via OAuth. Browsing the flag catalog
-  // is added on top of this in the follow-up PR.
+  // Gate the whole tab: nothing shows until the user connects via OAuth.
   if (!auth.isConnected) {
     return (
       <TabBase>
@@ -17,15 +21,70 @@ export function FlagsTab() {
     )
   }
 
+  // Remount the catalog on site change so filters, pagination, and accumulated tag suggestions don't
+  // carry over from a previously-connected org — stale filters would misleadingly empty the new
+  // catalog, and stale suggestions would leak the old org's tags into autocomplete.
+  return <ConnectedCatalog key={auth.site} auth={auth} />
+}
+
+function ConnectedCatalog({ auth }: { auth: FlagAuthState }) {
+  const view = useFlagCatalogView()
+  const catalog = useFlagCatalog(auth, view.request)
+  const { setPage } = view
+
+  const totalPages = Math.max(1, Math.ceil(catalog.total / view.pageSize))
+
+  // If the catalog shrinks (e.g. flags archived) so there are fewer pages than the selected one,
+  // snap back to the last page — Mantine's Pagination won't clamp an out-of-range value itself.
+  useEffect(() => {
+    if (view.page > totalPages) {
+      setPage(totalPages)
+    }
+  }, [view.page, totalPages, setPage])
+
+  // Progressive tag suggestions: there's no tags endpoint and we only load a page at a time, so the
+  // Tag filter's autocomplete is built from the tags seen on pages loaded so far. `team:*` tags are
+  // excluded (they'd drive a separate team filter); users can still type any tag not yet seen.
+  const [tagSuggestions, setTagSuggestions] = useState<string[]>([])
+  useEffect(() => {
+    setTagSuggestions((previous) => {
+      const seen = new Set(previous)
+      for (const flag of catalog.flags) {
+        for (const tag of flag.tags) {
+          if (!tag.startsWith('team:')) {
+            seen.add(tag)
+          }
+        }
+      }
+      // Keep the same array (skip the re-render) when this page added no new tags.
+      return seen.size === previous.length ? previous : Array.from(seen).sort((a, b) => a.localeCompare(b))
+    })
+  }, [catalog.flags])
+
   return (
     <TabBase
       top={
-        <Box px="md" className="dd-privacy-allow">
+        // No dd-privacy-allow here: the header/filter/catalog below render customer flag names,
+        // values, and tags, which must stay masked in the extension's own Session Replay.
+        <Box px="md">
           <ConnectionHeader auth={auth} />
+          <Space h="sm" />
+          <FlagFilterBar view={view} tagSuggestions={tagSuggestions} />
         </Box>
       }
     >
-      <Box px="md" py="sm" className="dd-privacy-allow" />
+      <Box px="md" py="sm">
+        <FlagCatalogBody catalog={catalog} flags={catalog.flags} total={catalog.total} />
+
+        {totalPages > 1 && (
+          <>
+            <Space h="sm" />
+            <Group justify="center">
+              <Pagination size="xs" color="violet" total={totalPages} value={view.page} onChange={view.setPage} />
+            </Group>
+          </>
+        )}
+      </Box>
     </TabBase>
   )
 }

--- a/developer-extension/src/panel/components/tabs/flagsTab/oauth.spec.ts
+++ b/developer-extension/src/panel/components/tabs/flagsTab/oauth.spec.ts
@@ -1,5 +1,13 @@
 import { registerCleanupTask, replaceMockable } from '../../../../../../packages/browser-core/test'
-import { getFlagsApiHost, loginWithOAuth, sha256 } from './oauth'
+import {
+  clearStoredTokens,
+  getFlagsApiHost,
+  getValidAccessToken,
+  loadStoredTokens,
+  loginWithOAuth,
+  sha256,
+  storeTokens,
+} from './oauth'
 
 describe('oauth', () => {
   describe('getFlagsApiHost', () => {
@@ -70,6 +78,132 @@ describe('oauth', () => {
 
       const tokens = await loginWithOAuth('datad0g.com')
       expect(tokens.accessToken).toBe('tok')
+    })
+  })
+
+  describe('getValidAccessToken', () => {
+    beforeEach(() => {
+      // In-memory chrome.storage.session so token read/write/remove work in the karma browser.
+      const previousChrome = (globalThis as any).chrome
+      const store: Record<string, unknown> = {}
+      ;(globalThis as any).chrome = {
+        storage: {
+          session: {
+            get: (key: string) => Promise.resolve({ [key]: store[key] }),
+            set: (items: Record<string, unknown>) => {
+              Object.assign(store, items)
+              return Promise.resolve()
+            },
+            remove: (key: string) => {
+              delete store[key]
+              return Promise.resolve()
+            },
+          },
+        },
+      }
+      registerCleanupTask(async () => {
+        await clearStoredTokens()
+        ;(globalThis as any).chrome = previousChrome
+      })
+    })
+
+    it('returns null when nothing is stored', async () => {
+      expect(await getValidAccessToken('datad0g.com')).toBeNull()
+    })
+
+    it('returns the stored token while it is still valid', async () => {
+      await storeTokens({ accessToken: 'valid', refreshToken: 'r1', expiresAt: Date.now() + 10 * 60_000 })
+      expect(await getValidAccessToken('datad0g.com')).toBe('valid')
+    })
+
+    it('refreshes an expired token and persists the new one', async () => {
+      await storeTokens({ accessToken: 'old', refreshToken: 'r1', expiresAt: Date.now() - 1 })
+      spyOn(globalThis, 'fetch').and.returnValue(
+        Promise.resolve(new Response(JSON.stringify({ access_token: 'fresh', refresh_token: 'r2', expires_in: 3600 })))
+      )
+
+      expect(await getValidAccessToken('datad0g.com')).toBe('fresh')
+      const stored = await loadStoredTokens()
+      expect(stored?.accessToken).toBe('fresh')
+      expect(stored?.refreshToken).toBe('r2')
+    })
+
+    it('keeps the previous refresh token when the refresh response omits one', async () => {
+      await storeTokens({ accessToken: 'old', refreshToken: 'r1', expiresAt: Date.now() - 1 })
+      spyOn(globalThis, 'fetch').and.returnValue(
+        Promise.resolve(new Response(JSON.stringify({ access_token: 'fresh', expires_in: 3600 })))
+      )
+
+      await getValidAccessToken('datad0g.com')
+      expect((await loadStoredTokens())?.refreshToken).toBe('r1')
+    })
+
+    it('clears tokens and returns null when the refresh token is invalid_grant', async () => {
+      await storeTokens({ accessToken: 'old', refreshToken: 'r1', expiresAt: Date.now() - 1 })
+      spyOn(globalThis, 'fetch').and.returnValue(
+        Promise.resolve(new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400 }))
+      )
+
+      expect(await getValidAccessToken('datad0g.com')).toBeNull()
+      expect(await loadStoredTokens()).toBeNull()
+    })
+
+    it('keeps the stored token and rethrows on a transient refresh failure after expiry', async () => {
+      await storeTokens({ accessToken: 'old', refreshToken: 'r1', expiresAt: Date.now() - 1 })
+      spyOn(globalThis, 'fetch').and.returnValue(Promise.resolve(new Response('server error', { status: 503 })))
+
+      await expectAsync(getValidAccessToken('datad0g.com')).toBeRejected()
+      expect((await loadStoredTokens())?.refreshToken).toBe('r1')
+    })
+
+    it('keeps the stored token and rethrows on a network error during refresh after expiry', async () => {
+      await storeTokens({ accessToken: 'old', refreshToken: 'r1', expiresAt: Date.now() - 1 })
+      spyOn(globalThis, 'fetch').and.returnValue(Promise.reject(new TypeError('Failed to fetch')))
+
+      await expectAsync(getValidAccessToken('datad0g.com')).toBeRejected()
+      expect((await loadStoredTokens())?.refreshToken).toBe('r1')
+    })
+
+    it('coalesces concurrent refreshes into a single token request', async () => {
+      await storeTokens({ accessToken: 'old', refreshToken: 'r1', expiresAt: Date.now() - 1 })
+      const fetchSpy = spyOn(globalThis, 'fetch').and.returnValue(
+        Promise.resolve(new Response(JSON.stringify({ access_token: 'fresh', refresh_token: 'r2', expires_in: 3600 })))
+      )
+
+      const [first, second] = await Promise.all([
+        getValidAccessToken('datad0g.com'),
+        getValidAccessToken('datad0g.com'),
+      ])
+
+      expect(first).toBe('fresh')
+      expect(second).toBe('fresh')
+      // The single-use refresh token must be spent exactly once even under concurrent callers.
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns the still-valid token on a transient refresh failure inside the skew window', async () => {
+      // Expires in 30s (inside the 60s skew) so we refresh early — but the token is still valid, so a
+      // transient failure should fall back to it rather than failing the caller.
+      await storeTokens({ accessToken: 'still-valid', refreshToken: 'r1', expiresAt: Date.now() + 30_000 })
+      spyOn(globalThis, 'fetch').and.returnValue(Promise.resolve(new Response('server error', { status: 503 })))
+
+      expect(await getValidAccessToken('datad0g.com')).toBe('still-valid')
+      expect((await loadStoredTokens())?.refreshToken).toBe('r1')
+    })
+
+    it('clears tokens and returns null when expired with no refresh token', async () => {
+      await storeTokens({ accessToken: 'old', expiresAt: Date.now() - 1 })
+
+      expect(await getValidAccessToken('datad0g.com')).toBeNull()
+      expect(await loadStoredTokens()).toBeNull()
+    })
+
+    it('keeps using a still-valid token that has no refresh token (skew only applies when refreshable)', async () => {
+      // Inside the 60s skew window, but unrefreshable — should return the token rather than clear it.
+      await storeTokens({ accessToken: 'valid', expiresAt: Date.now() + 30_000 })
+
+      expect(await getValidAccessToken('datad0g.com')).toBe('valid')
+      expect(await loadStoredTokens()).not.toBeNull()
     })
   })
 })

--- a/developer-extension/src/panel/components/tabs/flagsTab/oauth.ts
+++ b/developer-extension/src/panel/components/tabs/flagsTab/oauth.ts
@@ -10,6 +10,8 @@ import { mockable } from '../../../../../../packages/browser-core/src/tools/mock
 const CLIENT_ID = '13c94d15-067d-4263-a309-be4811141419'
 const SCOPES = ['feature_flag_config_read', 'feature_flag_environment_config_read']
 const TOKENS_STORAGE_KEY = 'flagsOAuthTokens'
+// Refresh a bit before the token actually expires to avoid racing the clock on a slow request.
+const EXPIRY_SKEW_MS = 60_000
 
 export interface OAuthTokens {
   accessToken: string
@@ -90,24 +92,43 @@ async function generatePkce(): Promise<{ verifier: string; challenge: string }> 
   return { verifier, challenge: base64UrlEncode(digest) }
 }
 
-function toTokens(raw: RawTokenResponse): OAuthTokens {
+// `fallbackRefreshToken` carries the previous refresh token forward: refresh responses often omit
+// `refresh_token` when the server doesn't rotate it, and dropping it would force a full re-login on
+// the next expiry.
+function toTokens(raw: RawTokenResponse, fallbackRefreshToken?: string): OAuthTokens {
   return {
     accessToken: raw.access_token,
-    refreshToken: raw.refresh_token,
+    refreshToken: raw.refresh_token ?? fallbackRefreshToken,
     expiresAt: Date.now() + (raw.expires_in ?? 3600) * 1000,
   }
 }
 
-async function requestToken(host: string, body: URLSearchParams): Promise<OAuthTokens> {
+// Thrown by requestToken on a non-ok response. `invalidGrant` marks the RFC 6749 `invalid_grant`
+// case — the refresh token itself is dead (expired/revoked/reused) — as opposed to a transient
+// failure (5xx, rate limit) that shouldn't be treated the same way.
+class TokenRequestError extends Error {
+  constructor(
+    message: string,
+    readonly invalidGrant: boolean
+  ) {
+    super(message)
+  }
+}
+
+async function requestToken(host: string, body: URLSearchParams, fallbackRefreshToken?: string): Promise<OAuthTokens> {
   const response = await fetch(`https://${host}/oauth2/v1/token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
   })
   if (!response.ok) {
-    throw new Error(`Token request failed: ${response.status} ${response.statusText}`)
+    const errorBody = (await response.json().catch(() => null)) as { error?: string } | null
+    throw new TokenRequestError(
+      `Token request failed: ${response.status} ${response.statusText}`,
+      errorBody?.error === 'invalid_grant'
+    )
   }
-  return toTokens((await response.json()) as RawTokenResponse)
+  return toTokens((await response.json()) as RawTokenResponse, fallbackRefreshToken)
 }
 
 /**
@@ -170,6 +191,18 @@ export async function loginWithOAuth(site: string): Promise<OAuthTokens> {
   )
 }
 
+function refreshTokens(site: string, refreshToken: string): Promise<OAuthTokens> {
+  return requestToken(
+    getFlagsApiHost(site),
+    new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: CLIENT_ID,
+    }),
+    refreshToken
+  )
+}
+
 export async function loadStoredTokens(): Promise<OAuthTokens | null> {
   const result = await chrome.storage.session.get(TOKENS_STORAGE_KEY)
   return (result[TOKENS_STORAGE_KEY] as OAuthTokens | undefined) ?? null
@@ -189,4 +222,58 @@ export async function clearStoredTokens(): Promise<void> {
  */
 export function isTokenUsable(tokens: OAuthTokens | null): boolean {
   return !!tokens && (tokens.expiresAt > Date.now() || !!tokens.refreshToken)
+}
+
+// Shared in-flight refresh. Each catalog request triggers a getValidAccessToken call, so several can
+// run at once; the refresh token is single-use (the server rotates it), so overlapping refreshes
+// must share one request. Otherwise the loser would replay a spent token, get invalid_grant, and
+// wipe the tokens the winner just stored — disconnecting the user mid-session.
+let pendingRefresh: Promise<OAuthTokens> | null = null
+
+/**
+ * Returns a currently-valid access token, transparently refreshing if it has expired. Returns
+ * null (and clears any stored tokens) when there is no usable token — the caller should then
+ * prompt the user to reconnect.
+ */
+export async function getValidAccessToken(site: string): Promise<string | null> {
+  const tokens = await loadStoredTokens()
+  if (!tokens) {
+    return null
+  }
+  // Refresh early (skew) only when we can actually refresh. Without a refresh token, applying the
+  // skew would discard the last 60s of a still-valid token and force an unnecessary reconnect.
+  const skew = tokens.refreshToken ? EXPIRY_SKEW_MS : 0
+  if (Date.now() < tokens.expiresAt - skew) {
+    return tokens.accessToken
+  }
+  if (tokens.refreshToken) {
+    try {
+      // Coalesce concurrent refreshes into a single request (see pendingRefresh). Capture the shared
+      // promise in a local so the `finally` clearing pendingRefresh can't race the await below.
+      const refresh = (pendingRefresh ??= refreshTokens(site, tokens.refreshToken)
+        .then(async (refreshed) => {
+          await storeTokens(refreshed)
+          return refreshed
+        })
+        .finally(() => {
+          pendingRefresh = null
+        }))
+      return (await refresh).accessToken
+    } catch (err) {
+      // A dead refresh token (invalid_grant) means the session is over — drop it and reconnect.
+      if (err instanceof TokenRequestError && err.invalidGrant) {
+        await clearStoredTokens()
+        return null
+      }
+      // Transient failure (network blip, 5xx). If we were only refreshing early — still inside the
+      // skew window, so the current token hasn't actually expired — keep using it rather than
+      // failing the caller; the refresh will be retried on the next call.
+      if (Date.now() < tokens.expiresAt) {
+        return tokens.accessToken
+      }
+      throw err
+    }
+  }
+  await clearStoredTokens()
+  return null
 }

--- a/developer-extension/src/panel/components/tabs/flagsTab/useFlagCatalog.ts
+++ b/developer-extension/src/panel/components/tabs/flagsTab/useFlagCatalog.ts
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react'
+import { createLogger } from '../../../../common/logger'
+import type { CatalogFlag, FlagCatalogRequest } from './flagCatalog'
+import { fetchFlagCatalog } from './flagCatalog'
+import { getValidAccessToken } from './oauth'
+import type { FlagAuthState } from './useFlagAuth'
+
+const logger = createLogger('useFlagCatalog')
+
+export interface FlagCatalogState {
+  flags: CatalogFlag[]
+  // Total number of flags matching the current filters, across all pages (server-reported).
+  total: number
+  loading: boolean
+  error: string | null
+}
+
+/**
+ * Loads one page of the flag catalog for the given request, letting the server do the filtering and
+ * pagination. Refetches whenever the connection, site, or request (page/search/filters) changes.
+ * Catalog failures are surfaced as a non-blocking error — the override read/write workflow works
+ * without any catalog.
+ */
+export function useFlagCatalog(auth: FlagAuthState, request: FlagCatalogRequest): FlagCatalogState {
+  const { isConnected, site, disconnect } = auth
+
+  const [flags, setFlags] = useState<CatalogFlag[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!isConnected) {
+      setFlags([])
+      setTotal(0)
+      setError(null)
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+
+    const load = async () => {
+      const token = await getValidAccessToken(site)
+      if (!token) {
+        // The stored session expired and couldn't be refreshed (getValidAccessToken cleared it).
+        // Flip back to the disconnected state so the tab shows the sign-in screen again, instead of
+        // staying "Connected" with a permanent catalog error and no obvious way to re-auth.
+        disconnect()
+        return { flags: [], total: 0 }
+      }
+      return fetchFlagCatalog(token, site, request)
+    }
+
+    load()
+      .then((page) => {
+        if (!cancelled) {
+          setFlags(page.flags)
+          setTotal(page.total)
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          logger.error('Error while fetching flag catalog:', err)
+          setFlags([])
+          setTotal(0)
+          setError(err instanceof Error ? err.message : String(err))
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [isConnected, site, disconnect, request])
+
+  return { flags, total, loading, error }
+}

--- a/developer-extension/src/panel/components/tabs/flagsTab/useFlagCatalogView.ts
+++ b/developer-extension/src/panel/components/tabs/flagsTab/useFlagCatalogView.ts
@@ -1,0 +1,67 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { FlagCatalogRequest } from './flagCatalog'
+
+const CATALOG_PAGE_SIZE = 20
+// Wait out a typing burst before sending a search to the server, so we don't fire a request per
+// keystroke. Short enough to still feel responsive.
+const SEARCH_DEBOUNCE_MS = 400
+
+export interface FlagCatalogView {
+  search: string
+  setSearch: (value: string) => void
+  typeFilter: string[]
+  setTypeFilter: (value: string[]) => void
+  tagFilter: string[]
+  setTagFilter: (value: string[]) => void
+  page: number
+  setPage: (value: number) => void
+  pageSize: number
+  // The filters + pagination to send to the server. Stable across renders unless a field changes.
+  request: FlagCatalogRequest
+}
+
+/**
+ * Owns the catalog's search/filter/pagination state and turns it into a server request. Filtering
+ * and pagination happen server-side (see useFlagCatalog), so this holds no flag data itself.
+ */
+export function useFlagCatalogView(): FlagCatalogView {
+  const [search, setSearchState] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [typeFilter, setTypeFilterState] = useState<string[]>([])
+  const [tagFilter, setTagFilterState] = useState<string[]>([])
+  const [page, setPage] = useState(1)
+
+  // Feed the server the debounced term, not the live one.
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedSearch(search), SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(id)
+  }, [search])
+
+  const request = useMemo<FlagCatalogRequest>(
+    () => ({ page, pageSize: CATALOG_PAGE_SIZE, search: debouncedSearch, typeFilter, tagFilter }),
+    [page, debouncedSearch, typeFilter, tagFilter]
+  )
+
+  // Any filter/search change resets to the first page so results aren't hidden on an out-of-range page.
+  return {
+    search,
+    setSearch: (value) => {
+      setSearchState(value)
+      setPage(1)
+    },
+    typeFilter,
+    setTypeFilter: (value) => {
+      setTypeFilterState(value)
+      setPage(1)
+    },
+    tagFilter,
+    setTagFilter: (value) => {
+      setTagFilterState(value)
+      setPage(1)
+    },
+    page,
+    setPage,
+    pageSize: CATALOG_PAGE_SIZE,
+    request,
+  }
+}

--- a/developer-extension/src/panel/monitoring.ts
+++ b/developer-extension/src/panel/monitoring.ts
@@ -4,7 +4,18 @@ import { DEFAULT_PANEL_TAB } from '../common/panelTabConstants'
 import { BASE_MONITORING_CONFIG, RUM_CONFIG } from '../common/monitoringConfig'
 
 export function initMonitoring() {
-  datadogRum.init(RUM_CONFIG)
+  datadogRum.init({
+    ...RUM_CONFIG,
+    beforeSend: (event) => {
+      // The feature-flags endpoint carries customer data (flag names/keys/tags) in its query string
+      // (search/tags/value_type). Strip the query from its resource events so those values never
+      // land in the extension's own RUM — the DOM is already masked for Session Replay.
+      if (event.type === 'resource' && event.resource.url.includes('/api/ui/ffe/feature-flags')) {
+        event.resource.url = event.resource.url.replace(/\?.*$/, '')
+      }
+      return true
+    },
+  })
   datadogRum.startSessionReplayRecording()
   datadogRum.startView(DEFAULT_PANEL_TAB)
 


### PR DESCRIPTION
## Motivation

Stacked on **#4913** (OAuth, now merged). With sign-in in place, this PR lets users **browse their feature-flag catalog** from the extension. Overriding flags is the next PR (#4912).

## Stack (review bottom-up)

| | PR | Base | What it adds |
|---|---|---|---|
| 1 of 3 | #4913 · FFL-2597 | `main` | OAuth sign-in — ✅ merged |
| **2 of 3** | **#4916 (this)** · FFL-2858 | `main` | catalog browsing |
| 3 of 3 | #4912 · FFL-2596 | `ffl-2858` | flag overrides |

## Changes
- Browses the catalog via the OAuth-capable `GET /api/ui/ffe/feature-flags` endpoint, **server-side**: the extension fetches only the page it's showing and lets the endpoint apply **search / type / tag filtering + pagination** (`meta.page.total`) — it never loads the whole catalog.
- **Search** (debounced), **Type** filter (fixed set), and **Tags** as free-text with progressive autocomplete.
- OAuth token handling — `getValidAccessToken` refreshes transparently, with **single-flight refresh** so concurrent requests can't spend the rotating refresh token twice.
- **Privacy:** a RUM `beforeSend` strips customer data (flag names/keys/tags carried in query params) from this endpoint's resource events in the extension's own telemetry.
- Defensive variant-value parsing + dedupe-by-key.

## Recently changed
- **Pivoted to server-side pagination + filtering** (previously fetched the *entire* catalog and filtered client-side). Per review: the extension re-fetches on every panel open and the endpoint caps pages at 50, so loading ~2k flags meant many sequential requests. It now fetches one page per view.
- **Design decisions worth calling out:**
  - **Tags filter is free-text** (with suggestions accumulated from loaded pages) rather than a full dropdown — there's no tags/facets endpoint to enumerate all tags once we stopped loading the whole catalog. Type stays a real dropdown (fixed set).
  - **Search debounced at ~400ms** — responsive while avoiding a request per keystroke.
- **Addressed the Codex review:** single-flight token refresh (prevents a spurious disconnect when concurrent refreshes race near expiry), a RUM query-string scrub for the FFE endpoint, page-clamp when the catalog shrinks, remount on site change (avoids stale filters / another org's tag suggestions leaking in), and a raw-string fallback for an unknown `value_type`.

## Demo
This is what the three PRs look like working together:

https://github.com/user-attachments/assets/6ebece86-8c38-4bad-9366-9bf2dd643ca5

## Checklist
- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change (`oauth.spec.ts` — `getValidAccessToken` incl. refresh/skew/coalescing; `flagCatalog.spec.ts`).
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
