### PR TITLE
✨ Add a version-agnostic React Router entry point

### DIFF
--- a/packages/browser-rum-react/README.md
+++ b/packages/browser-rum-react/README.md
@@ -1,7 +1,207 @@
 # RUM Browser Monitoring - React integration
 
-This package provides React and React ecosystem integrations for Datadog Browser RUM.
+## Overview
 
-See the [dedicated Datadog documentation][1] for more details.
+With the Datadog RUM React integration, resolve performance issues quickly in React components by:
 
-[1]: https://docs.datadoghq.com/integrations/rum_react
+- Debugging the root cause of performance bottlenecks, such as a slow server response time, render-blocking resource, or an error inside a component
+- Automatically correlating web performance data with user journeys, HTTP calls, and logs
+- Alerting your engineering teams when crucial web performance metrics (such as Core Web Vitals) fall below a threshold that results in a poor user experience
+
+Monitor your React applications from end-to-end by:
+
+- Tracking and visualizing user journeys across your entire stack
+- Debugging the root cause of slow load times, which may be an issue with your React code, network performance, or underlying infrastructure
+- Analyzing and contextualizing every user session with attributes such as user ID, email, name, and more
+- Unifying full-stack monitoring in one platform for frontend and backend development teams
+
+## Setup
+
+Start by setting up [Datadog RUM][1] in your React application. If you're creating a new RUM application in the Datadog App, select React as the application type. If you already have an existing RUM application, you can update its type to React instead. Once configured, the Datadog App will provide instructions for integrating the [RUM-React plugin][2] with the Browser SDK.
+
+This integration supports **React v18 or v19**.
+
+## Error Tracking
+
+To track React component rendering errors, use one of the following:
+
+- An `ErrorBoundary` component (see [React documentation][3]) that catches errors and reports them to Datadog.
+- A function that you can use to report errors from your own `ErrorBoundary` component.
+
+### `ErrorBoundary` usage
+
+```javascript
+import { ErrorBoundary } from '@datadog/browser-rum-react'
+
+function App() {
+  return (
+    <ErrorBoundary fallback={ErrorFallback}>
+      <MyComponent />
+    </ErrorBoundary>
+  )
+}
+
+function ErrorFallback({ resetError, error }) {
+  return (
+    <p>
+      Oops, something went wrong! <strong>{String(error)}</strong> <button onClick={resetError}>Retry</button>
+    </p>
+  )
+}
+```
+
+### Reporting React errors from your own `ErrorBoundary`
+
+```javascript
+import { addReactError } from '@datadog/browser-rum-react'
+
+class MyErrorBoundary extends React.Component {
+  componentDidCatch(error, errorInfo) {
+    addReactError(error, errorInfo)
+  }
+
+  render() {
+    // ...
+  }
+}
+```
+
+## React 19 `createRoot` Error Handling
+
+React 19 introduced new error handling options for `createRoot` that can help capture errors more effectively. You can configure these options to work with Datadog RUM error tracking. See the [createRoot documentation](https://react.dev/reference/react-dom/client/createRoot#parameters) for more details:
+
+```javascript
+import { createRoot } from 'react-dom/client'
+import { addReactError } from '@datadog/browser-rum-react'
+
+const container = document.getElementById('root')
+const root = createRoot(container, {
+  onUncaughtError: (error, errorInfo) => {
+    // Report uncaught errors to Datadog
+    addReactError(error, errorInfo)
+    console.error('Uncaught error:', error, errorInfo)
+  },
+  onCaughtError: (error, errorInfo) => {
+    // Report caught errors to Datadog
+    addReactError(error, errorInfo)
+    console.error('Caught error:', error, errorInfo)
+  },
+  onRecoverableError: (error, errorInfo) => {
+    // Report recoverable errors to Datadog
+    addReactError(error, errorInfo)
+    console.warn('Recoverable error:', error, errorInfo)
+  },
+})
+
+root.render(<App />)
+```
+
+These options provide comprehensive error coverage:
+
+- `onUncaughtError`: Captures errors that would normally cause the app to crash
+- `onCaughtError`: Captures errors that are caught by error boundaries
+- `onRecoverableError`: Captures errors that React can recover from (like hydration mismatches)
+
+## React Router integration
+
+React Router v6, v7, and v8 allow you to declare routes using the following methods:
+
+- Create routers with [`createMemoryRouter`][4], [`createHashRouter`][5], or [`createBrowserRouter`][6] functions.
+- Use the [`useRoutes`][7] hook.
+- Use the [`Routes`][8] component.
+
+To track route changes with the Datadog RUM Browser SDK, first initialize the `reactPlugin` with the `router: true` option, then replace those functions with their equivalent from the matching Datadog entry point. The version-agnostic entry point targets the latest supported React Router version:
+
+| Supported React Router version | Entry point                                  | Usage            |
+| ------------------------------ | -------------------------------------------- | ---------------- |
+| Latest (currently v8)          | `@datadog/browser-rum-react/react-router`    | Recommended      |
+| v8                             | `@datadog/browser-rum-react/react-router-v8` | Version-specific |
+| v7                             | `@datadog/browser-rum-react/react-router-v7` | Version-specific |
+| v6                             | `@datadog/browser-rum-react/react-router-v6` | Version-specific |
+
+```javascript
+import { createRoot } from 'react-dom/client'
+import { RouterProvider } from 'react-router/dom'
+import { datadogRum } from '@datadog/browser-rum'
+import { reactPlugin } from '@datadog/browser-rum-react'
+// Use "createBrowserRouter" from @datadog/browser-rum-react/react-router instead of react-router:
+import { createBrowserRouter } from '@datadog/browser-rum-react/react-router'
+
+datadogRum.init({
+  // ...
+  plugins: [reactPlugin({ router: true })],
+})
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Root />,
+    // ...
+  },
+])
+
+createRoot(document.getElementById('root')).render(<RouterProvider router={router} />)
+```
+
+## TanStack Router integration
+
+[TanStack Router][14] v1.64.0 or later is a typesafe router for React. To track route changes with the Datadog RUM Browser SDK, first initialize the `reactPlugin` with the `router: true` option, then replace `createRouter` from `@tanstack/react-router` with its equivalent from `@datadog/browser-rum-react/tanstack-router`. Example:
+
+```javascript
+import { createRoot } from 'react-dom/client'
+import { RouterProvider } from '@tanstack/react-router'
+import { datadogRum } from '@datadog/browser-rum'
+import { reactPlugin } from '@datadog/browser-rum-react'
+// Use "createRouter" from @datadog/browser-rum-react/tanstack-router instead of @tanstack/react-router:
+import { createRouter } from '@datadog/browser-rum-react/tanstack-router'
+
+datadogRum.init({
+  // ...
+  plugins: [reactPlugin({ router: true })],
+})
+
+const router = createRouter({ routeTree })
+
+createRoot(document.getElementById('root')).render(<RouterProvider router={router} />)
+```
+
+RUM creates a new view on every path change. The view name uses the route's `fullPath` template, so navigating to `/posts/42` is reported as `/posts/$postId`. Catch-all (splat) segments are replaced with the matched path, so `/files/$` with `_splat = "path/to/file"` becomes `/files/path/to/file`. Query string changes do not create a new view.
+
+## Go further with Datadog React integration
+
+### Traces
+
+Connect your RUM and trace data to get a complete view of your application's performance. See [Connect RUM and Traces][9].
+
+### Logs
+
+To start forwarding your React application's logs to Datadog, see [JavaScript Logs Collection][10].
+
+### Metrics
+
+To generate custom metrics from your RUM application, see [Generate Metrics][11].
+
+## Troubleshooting
+
+Need help? Contact [Datadog Support][12].
+
+## Further Reading
+
+Additional helpful documentation, links, and articles:
+
+- [React Monitoring][13]
+
+[1]: https://docs.datadoghq.com/real_user_monitoring/browser/setup/client
+[2]: https://www.npmjs.com/package/@datadog/browser-rum-react
+[3]: https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
+[4]: https://reactrouter.com/en/main/routers/create-memory-router
+[5]: https://reactrouter.com/en/main/routers/create-hash-router
+[6]: https://reactrouter.com/en/main/routers/create-browser-router
+[7]: https://reactrouter.com/en/main/hooks/use-routes
+[8]: https://reactrouter.com/en/main/components/routes
+[9]: https://docs.datadoghq.com/real_user_monitoring/platform/connect_rum_and_traces/?tab=browserrum
+[10]: https://docs.datadoghq.com/logs/log_collection/javascript/
+[11]: https://docs.datadoghq.com/real_user_monitoring/generate_metrics
+[12]: https://docs.datadoghq.com/help/
+[13]: https://www.datadoghq.com/blog/datadog-rum-react-components/
+[14]: https://tanstack.com/router/latest

--- a/packages/browser-rum-react/README.md
+++ b/packages/browser-rum-react/README.md
@@ -23,10 +23,13 @@ This integration supports **React v18 or v19**.
 
 ## Error Tracking
 
-To track React component rendering errors, use one of the following:
+To track React component rendering errors, choose one of the following approaches:
 
 - An `ErrorBoundary` component (see [React documentation][3]) that catches errors and reports them to Datadog.
-- A function that you can use to report errors from your own `ErrorBoundary` component.
+- The `addReactError` function from your own `ErrorBoundary` component.
+- In React 19, the `onCaughtError` option from `createRoot`.
+
+Do not report the same caught error from both an `ErrorBoundary` and `onCaughtError`, as this creates duplicate RUM error events.
 
 ### `ErrorBoundary` usage
 
@@ -68,7 +71,9 @@ class MyErrorBoundary extends React.Component {
 
 ## React 19 `createRoot` Error Handling
 
-React 19 introduced new error handling options for `createRoot` that can help capture errors more effectively. You can configure these options to work with Datadog RUM error tracking. See the [createRoot documentation](https://react.dev/reference/react-dom/client/createRoot#parameters) for more details:
+React 19 introduced new error handling options for `createRoot` that can help capture errors more effectively. You can configure these options to work with Datadog RUM error tracking. See the [createRoot documentation](https://react.dev/reference/react-dom/client/createRoot#parameters) for more details.
+
+The following example reports caught errors centrally through `onCaughtError`. Error boundaries are still needed to catch errors and render fallback UI, but they must not also call `addReactError`. If your application already uses the Datadog `ErrorBoundary`, or calls `addReactError` from a custom boundary's `componentDidCatch`, omit `onCaughtError` to avoid reporting caught errors twice.
 
 ```javascript
 import { createRoot } from 'react-dom/client'

--- a/packages/browser-rum-react/package.json
+++ b/packages/browser-rum-react/package.json
@@ -10,6 +10,7 @@
     "esm",
     "src",
     "internal",
+    "react-router",
     "react-router-v6",
     "react-router-v7",
     "react-router-v8",

--- a/packages/browser-rum-react/react-router/package.json
+++ b/packages/browser-rum-react/react-router/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@datadog/browser-rum-react/react-router",
+  "private": true,
+  "main": "../cjs/entries/reactRouterV8.js",
+  "module": "../esm/entries/reactRouterV8.mjs",
+  "types": "../cjs/entries/reactRouterV8.d.ts"
+}

--- a/packages/browser-rum-react/react-router/typedoc.json
+++ b/packages/browser-rum-react/react-router/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["../src/entries/reactRouterV8.ts"]
+}

--- a/packages/browser-rum-react/src/domain/reactPlugin.ts
+++ b/packages/browser-rum-react/src/domain/reactPlugin.ts
@@ -17,8 +17,7 @@ const onRumStartSubscribers: StartSubscriber[] = []
 export interface ReactPluginConfiguration {
   /**
    * Enable router integration. Make sure to use functions from
-   * {@link @datadog/browser-rum-react/react-router-v6! | @datadog/browser-rum-react/react-router-v6},
-   * {@link @datadog/browser-rum-react/react-router-v7! | @datadog/browser-rum-react/react-router-v7}, or
+   * {@link @datadog/browser-rum-react/react-router! | @datadog/browser-rum-react/react-router} or
    * {@link @datadog/browser-rum-react/tanstack-router! | @datadog/browser-rum-react/tanstack-router}
    * to create the router.
    * ```

--- a/packages/browser-rum-react/src/entries/reactRouterV8.ts
+++ b/packages/browser-rum-react/src/entries/reactRouterV8.ts
@@ -8,8 +8,8 @@
  * import { datadogRum } from '@datadog/browser-rum'
  * import { reactPlugin } from '@datadog/browser-rum-react'
  *
- * // ⚠️ Use "createBrowserRouter" from `@datadog/browser-rum-react/react-router-v8` instead of `react-router`
- * import { createBrowserRouter } from '@datadog/browser-rum-react/react-router-v8'
+ * // ⚠️ Use "createBrowserRouter" from `@datadog/browser-rum-react/react-router` instead of `react-router`
+ * import { createBrowserRouter } from '@datadog/browser-rum-react/react-router'
  *
  * datadogRum.init({
  *   applicationId: '<DATADOG_APPLICATION_ID>',

--- a/scripts/build/build-test-apps.ts
+++ b/scripts/build/build-test-apps.ts
@@ -184,7 +184,7 @@ async function buildReactRouterV6App() {
 
     await modifyFile(path.join(appPath, 'app.tsx'), (content: string) =>
       content
-        .replace('@datadog/browser-rum-react/react-router-v8', '@datadog/browser-rum-react/react-router-v6')
+        .replace('@datadog/browser-rum-react/react-router', '@datadog/browser-rum-react/react-router-v6')
         .replace("from 'react-router'", "from 'react-router-dom'")
         // Remove the v7-only onError prop
         .replace(
@@ -218,7 +218,7 @@ async function buildReactRouterV7App() {
     )
 
     await modifyFile(path.join(appPath, 'app.tsx'), (content: string) =>
-      content.replace('@datadog/browser-rum-react/react-router-v8', '@datadog/browser-rum-react/react-router-v7')
+      content.replace('@datadog/browser-rum-react/react-router', '@datadog/browser-rum-react/react-router-v7')
     )
 
     await modifyFile(path.join(appPath, 'webpack.config.js'), (content: string) =>

--- a/test/apps/react-router-app/app.tsx
+++ b/test/apps/react-router-app/app.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from '@datadog/browser-rum-react/react-router-v8'
+import { createBrowserRouter } from '@datadog/browser-rum-react/react-router'
 import { RouterProvider, Link, useParams, Outlet } from 'react-router'
 import React, { useState } from 'react'
 import ReactDOM from 'react-dom/client'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,6 +31,7 @@
 
       "@datadog/browser-rum-react": ["./packages/browser-rum-react/src/entries/main"],
       "@datadog/browser-rum-react/internal": ["./packages/browser-rum-react/src/entries/internal"],
+      "@datadog/browser-rum-react/react-router": ["./packages/browser-rum-react/src/entries/reactRouterV8"],
       "@datadog/browser-rum-react/react-router-v6": ["./packages/browser-rum-react/src/entries/reactRouterV6"],
       "@datadog/browser-rum-react/react-router-v7": ["./packages/browser-rum-react/src/entries/reactRouterV7"],
       "@datadog/browser-rum-react/react-router-v8": ["./packages/browser-rum-react/src/entries/reactRouterV8"],

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,13 @@
 {
-  "entryPoints": ["packages/*", "packages/browser-rum-react/react-router", "packages/browser-rum-vue/vue-router"],
+  "entryPoints": [
+    "packages/*",
+    "packages/browser-rum-react/react-router",
+    "packages/browser-rum-react/react-router-v6",
+    "packages/browser-rum-react/react-router-v7",
+    "packages/browser-rum-react/react-router-v8",
+    "packages/browser-rum-vue/vue-router",
+    "packages/browser-rum-vue/vue-router-v4"
+  ],
   "entryPointStrategy": "packages",
   "includeVersion": true,
   "exclude": [

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,10 +1,5 @@
 {
-  "entryPoints": [
-    "packages/*",
-    "packages/browser-rum-react/react-router-v6",
-    "packages/browser-rum-react/react-router-v7",
-    "packages/browser-rum-vue/vue-router-v4"
-  ],
+  "entryPoints": ["packages/*", "packages/browser-rum-react/react-router", "packages/browser-rum-vue/vue-router-v4"],
   "entryPointStrategy": "packages",
   "includeVersion": true,
   "exclude": [


### PR DESCRIPTION
## Motivation

`@datadog/browser-rum-react` supports React Router v6, v7, and v8, but only exposes version-specific router entry points. Documentation also needs to be updated manually whenever support for a new React Router version is added.

A version-agnostic entry point lets the default integration follow the latest supported React Router version while keeping explicit versioned imports available for applications that need them.

## Changes

- Add `@datadog/browser-rum-react/react-router` as the version-agnostic router entry point, currently targeting React Router v8.
- Keep `react-router-v6`, `react-router-v7`, and `react-router-v8` available for explicit version selection and backward compatibility.
- Update TypeScript paths, TypeDoc configuration, API documentation, and the latest React Router test app to use the generic entry point.
- Add readme to follow the same pattern as other plugins. 

## Test instructions

No changes, CI should pass. 

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file
