### PR TITLE
⚗️ Partial view updates — reduce checkpoint interval

### DIFF
--- a/packages/browser-rum-core/src/transport/startRumBatch.spec.ts
+++ b/packages/browser-rum-core/src/transport/startRumBatch.spec.ts
@@ -214,8 +214,8 @@ describe('computeAssembledViewDiff', () => {
 })
 
 describe('startRumBatch partial_view_updates routing', () => {
-  it('PARTIAL_VIEW_UPDATE_CHECKPOINT_INTERVAL should be 100', () => {
-    expect(PARTIAL_VIEW_UPDATE_CHECKPOINT_INTERVAL).toBe(100)
+  it('PARTIAL_VIEW_UPDATE_CHECKPOINT_INTERVAL should be 10', () => {
+    expect(PARTIAL_VIEW_UPDATE_CHECKPOINT_INTERVAL).toBe(10)
   })
 })
 

--- a/packages/browser-rum-core/src/transport/startRumBatch.ts
+++ b/packages/browser-rum-core/src/transport/startRumBatch.ts
@@ -10,7 +10,7 @@ import type { RumViewEvent, RumViewUpdateEvent } from '../rumEvent.types'
 import { RumEventType } from '../rawRumEvent.types'
 import { diffMerge } from '../domain/view/viewDiff'
 
-export const PARTIAL_VIEW_UPDATE_CHECKPOINT_INTERVAL = 100
+export const PARTIAL_VIEW_UPDATE_CHECKPOINT_INTERVAL = 10
 
 export type AssembledViewDiff = Omit<RumViewUpdateEvent, 'view' | '_dd'> & {
   view: Partial<RumViewEvent['view']> & { id: string; url: string }


### PR DESCRIPTION
## Motivation

The checkpoint interval controls how often the SDK sends a full VIEW snapshot when using partial view updates. At 100, the backend could work from a base that's up to 99 diffs old if the session drops before the next checkpoint. 10 is a more conservative value that cuts the worst-case staleness by 10x. The bandwidth cost is small since the checkpoint only sends one full VIEW regardless of how many diffs landed in between.

## Changes

One-line change to `PARTIAL_VIEW_UPDATE_CHECKPOINT_INTERVAL` in `startRumBatch.ts`. Updated the unit test that asserts the constant value.

## Test instructions

1. `yarn dev`, open `http://localhost:8080`
2. Add `enableExperimentalFeatures: ['partial_view_updates']` to the `DD_RUM.init()` call in `sandbox/index.html`
3. Flush first: `window.dispatchEvent(new Event('beforeunload'))`
4. Trigger 11+ view updates: `for (let i = 0; i < 12; i++) DD_RUM.setViewName('step-' + i)`
5. Flush: `window.dispatchEvent(new Event('beforeunload'))`
6. In the Network tab, the second proxy request should contain a full VIEW (not a `view_update`), confirming the checkpoint fired at 10.

Or just `yarn test:unit --spec packages/browser-rum-core/src/transport/startRumBatch.spec.ts`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file