### PR TITLE
⚗️ Add 128-bit trace IDs for Browser RUM

### DIFF
--- a/packages/browser-core/src/tools/experimentalFeatures.ts
+++ b/packages/browser-core/src/tools/experimentalFeatures.ts
@@ -14,6 +14,7 @@ import { objectHasValue } from './utils/objectUtils'
 
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
+  TRACE_ID_128_BIT = 'trace_id_128_bit',
   TRACK_INTAKE_REQUESTS = 'track_intake_requests',
   TRACK_WEBSOCKETS = 'track_websockets',
 }

--- a/packages/browser-rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/browser-rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -1185,6 +1185,37 @@ describe('resourceCollection', () => {
       expect(privateFields.span_id).toBeDefined()
     })
 
+    it('should use a decimal trace id for a sampled request with a 64-bit trace id', () => {
+      const traceId = createTraceIdentifier()
+      setupResourceCollection()
+      notifyRequest({
+        request: {
+          traceSampled: true,
+          spanId: createSpanIdentifier(),
+          traceId,
+        },
+      })
+
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd
+      expect(privateFields.trace_id).toBe(traceId.toLowDecimalString())
+    })
+
+    it('should use a full hexadecimal trace id for a sampled request with a 128-bit trace id', () => {
+      const traceId = createTraceIdentifier(128)
+      setupResourceCollection()
+      notifyRequest({
+        request: {
+          traceSampled: true,
+          spanId: createSpanIdentifier(),
+          traceId,
+        },
+      })
+
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd
+      expect(privateFields.trace_id).toBe(traceId.toHexString())
+      expect(privateFields.trace_id).toMatch(/^[0-9a-f]{32}$/)
+    })
+
     it('should not be processed from not sampled completed request', () => {
       setupResourceCollection()
       notifyRequest({

--- a/packages/browser-rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/browser-rum-core/src/domain/resource/resourceCollection.ts
@@ -275,14 +275,14 @@ function getResourceDomainContext(
 }
 
 function computeRequestTracingInfo(request: RequestCompleteEvent, configuration: RumConfiguration) {
-  const hasBeenTraced = request.traceSampled && request.traceId && request.spanId
-  if (!hasBeenTraced) {
+  if (!request.traceSampled || !request.traceId || !request.spanId) {
     return undefined
   }
+  const { traceId, spanId } = request
   return {
     _dd: {
-      span_id: request.spanId!.toString(),
-      trace_id: request.traceId!.toString(),
+      span_id: spanId.toString(),
+      trace_id: traceId.toHighHexString() === undefined ? traceId.toLowDecimalString() : traceId.toHexString(),
       rule_psr: configuration.rulePsr,
     },
   }

--- a/packages/browser-rum-core/src/domain/tracing/identifier.spec.ts
+++ b/packages/browser-rum-core/src/domain/tracing/identifier.spec.ts
@@ -1,3 +1,5 @@
+import { dateNow } from '@datadog/js-core/time'
+import { replaceMockable } from '@datadog/browser-core/test'
 import { createSpanIdentifier, createTraceIdentifier, toPaddedHexadecimalString } from './identifier'
 
 describe('identifier', () => {
@@ -17,6 +19,34 @@ describe('identifier', () => {
       mockRandomValues((buffer) => buffer.fill(0xff))
       const identifier = createTraceIdentifier()
       expect(identifier.toString(16)).toEqual('ffffffffffffffff')
+    })
+
+    it('formats a 64-bit identifier explicitly', () => {
+      mockRandomValues((buffer) => (buffer[0] = 0xff))
+      const identifier = createTraceIdentifier()
+
+      expect(identifier.toLowDecimalString()).toEqual('255')
+      expect(identifier.toHexString()).toEqual('00000000000000ff')
+      expect(identifier.toHighHexString()).toBeUndefined()
+    })
+
+    it('generates and formats a 128-bit identifier', () => {
+      replaceMockable(dateNow, () => 0x12345678 * 1000)
+      mockRandomValues((buffer) => (buffer[0] = 0xff))
+      const identifier = createTraceIdentifier(128)
+
+      expect(identifier.toString()).toEqual('255')
+      expect(identifier.toLowDecimalString()).toEqual('255')
+      expect(identifier.toHighHexString()).toEqual('1234567800000000')
+      expect(identifier.toHexString()).toEqual('123456780000000000000000000000ff')
+    })
+
+    it('masks the timestamp to 32 bits', () => {
+      replaceMockable(dateNow, () => 0x112345678 * 1000)
+      const identifier = createTraceIdentifier(128)
+
+      expect(identifier.toHighHexString()).toEqual('1234567800000000')
+      expect(identifier.toHexString()).toHaveSize(32)
     })
   })
 

--- a/packages/browser-rum-core/src/domain/tracing/identifier.ts
+++ b/packages/browser-rum-core/src/domain/tracing/identifier.ts
@@ -1,19 +1,31 @@
+import { mockable } from '@datadog/browser-core'
+import { dateNow } from '@datadog/js-core/time'
+
 interface BaseIdentifier {
   toString(radix?: number): string
 }
 
 export interface TraceIdentifier extends BaseIdentifier {
-  // We use a brand to distinguish between TraceIdentifier and SpanIdentifier, else TypeScript
-  // considers them as the same type
-  __brand: 'traceIdentifier'
+  toLowDecimalString(): string
+  toHexString(): string
+  toHighHexString(): string | undefined
 }
 
 export interface SpanIdentifier extends BaseIdentifier {
   __brand: 'spanIdentifier'
 }
 
-export function createTraceIdentifier() {
-  return createIdentifier(64) as TraceIdentifier
+export function createTraceIdentifier(bitLength: 64 | 128 = 64): TraceIdentifier {
+  const low = createIdentifier(64)
+  const high = bitLength === 128 ? createTraceIdentifierHighBits() : undefined
+  const highHex = high === undefined ? undefined : toPaddedHexadecimalString(high)
+
+  return {
+    toString: (radix) => low.toString(radix),
+    toLowDecimalString: () => low.toString(),
+    toHexString: () => `${highHex ?? ''}${toPaddedHexadecimalString(low)}`,
+    toHighHexString: () => highHex,
+  }
 }
 
 export function createSpanIdentifier() {
@@ -31,6 +43,14 @@ function createIdentifier(bits: 63 | 64): BaseIdentifier {
     value &= 0x7fffffffffffffffn // force 63-bit by clearing the top bit
   }
   return value
+}
+
+function createTraceIdentifierHighBits(): bigint {
+  // Keep the trace ID layout aligned with other Datadog SDKs:
+  // <32-bit Unix timestamp><32 zero bits><64 random bits>.
+  // Mask the timestamp to guarantee that the high part remains 64 bits after 2106.
+  // eslint-disable-next-line no-bitwise
+  return (BigInt(Math.floor(mockable(dateNow)() / 1000)) & 0xffffffffn) << 32n
 }
 
 export function toPaddedHexadecimalString(id: BaseIdentifier) {

--- a/packages/browser-rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/browser-rum-core/src/domain/tracing/tracer.spec.ts
@@ -1,5 +1,11 @@
 import type { ContextManager, ContextValue } from '@datadog/browser-core'
-import { display, objectEntries, TraceContextInjection } from '@datadog/browser-core'
+import {
+  addExperimentalFeatures,
+  display,
+  ExperimentalFeature,
+  objectEntries,
+  TraceContextInjection,
+} from '@datadog/browser-core'
 import type { SessionManagerMock } from '@datadog/browser-core/test'
 import { MID_HASH_UUID, MOCK_SESSION_ID, createSessionManagerMock } from '@datadog/browser-core/test'
 import type { RumFetchResolveContext, RumFetchStartContext, RumXhrStartContext } from '../requestCollection'
@@ -211,6 +217,43 @@ describe('tracer', () => {
           tracestate: 'dd=s:1;o:rum',
         })
       )
+    })
+
+    it('should propagate the same 128-bit trace id with every propagator', () => {
+      addExperimentalFeatures([ExperimentalFeature.TRACE_ID_128_BIT])
+      const tracer = startTracerWithDefaults({
+        initConfiguration: {
+          allowedTracingUrls: [
+            { match: window.location.origin, propagatorTypes: ['datadog', 'tracecontext', 'b3', 'b3multi'] },
+          ],
+        },
+      })
+      const context = { ...ALLOWED_DOMAIN_CONTEXT }
+      tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
+
+      const traceId = context.traceId!
+      const fullTraceId = traceId.toHexString()
+      const highTraceId = traceId.toHighHexString()!
+      expect(fullTraceId).toMatch(/^[0-9a-f]{8}00000000[0-9a-f]{16}$/)
+      expect(xhr.headers['x-datadog-trace-id']).toBe(traceId.toLowDecimalString())
+      expect(xhr.headers['x-datadog-tags']).toBe(`_dd.p.tid=${highTraceId}`)
+      expect(xhr.headers['traceparent']).toContain(`-${fullTraceId}-`)
+      expect(xhr.headers['b3'].startsWith(`${fullTraceId}-`)).toBeTrue()
+      expect(xhr.headers['X-B3-TraceId']).toBe(fullTraceId)
+    })
+
+    it('should not add x-datadog-tags without the Datadog propagator', () => {
+      addExperimentalFeatures([ExperimentalFeature.TRACE_ID_128_BIT])
+      const tracer = startTracerWithDefaults({
+        initConfiguration: {
+          allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['tracecontext'] }],
+        },
+      })
+      const context = { ...ALLOWED_DOMAIN_CONTEXT }
+      tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
+
+      expect(xhr.headers['x-datadog-tags']).toBeUndefined()
+      expect(xhr.headers['traceparent']).toContain(`-${context.traceId!.toHexString()}-`)
     })
 
     it('should not add any headers', () => {
@@ -741,11 +784,13 @@ function toPlainObject(headers: Headers) {
 }
 
 function tracingHeadersFor(traceId: TraceIdentifier, spanId: SpanIdentifier, samplingPriority: '1' | '0') {
+  const highTraceId = traceId.toHighHexString()
   return {
     'x-datadog-origin': 'rum',
     'x-datadog-parent-id': spanId.toString(),
     'x-datadog-sampling-priority': samplingPriority,
-    'x-datadog-trace-id': traceId.toString(),
+    'x-datadog-trace-id': traceId.toLowDecimalString(),
+    ...(highTraceId && { 'x-datadog-tags': `_dd.p.tid=${highTraceId}` }),
     baggage: `session.id=${MOCK_SESSION_ID},user.id=1234,account.id=5678`,
   }
 }

--- a/packages/browser-rum-core/src/domain/tracing/tracer.ts
+++ b/packages/browser-rum-core/src/domain/tracing/tracer.ts
@@ -8,6 +8,8 @@ import {
   isSampled,
   canUseEventBridge,
   getEventBridge,
+  ExperimentalFeature,
+  isExperimentalFeatureEnabled,
 } from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
 import type {
@@ -150,7 +152,7 @@ function injectHeadersIfTracingAllowed(
   }
 
   context.traceSampled = traceSampled
-  context.traceId = createTraceIdentifier()
+  context.traceId = createTraceIdentifier(isExperimentalFeatureEnabled(ExperimentalFeature.TRACE_ID_128_BIT) ? 128 : 64)
   context.spanId = createSpanIdentifier()
 
   inject(
@@ -190,14 +192,18 @@ function makeTracingHeaders(
           'x-datadog-origin': 'rum',
           'x-datadog-parent-id': spanId.toString(),
           'x-datadog-sampling-priority': traceSampled ? '1' : '0',
-          'x-datadog-trace-id': traceId.toString(),
+          'x-datadog-trace-id': traceId.toLowDecimalString(),
         })
+        const highTraceId = traceId.toHighHexString()
+        if (highTraceId) {
+          tracingHeaders['x-datadog-tags'] = `_dd.p.tid=${highTraceId}`
+        }
         break
       }
       // https://www.w3.org/TR/trace-context/
       case 'tracecontext': {
         Object.assign(tracingHeaders, {
-          traceparent: `00-0000000000000000${toPaddedHexadecimalString(traceId)}-${toPaddedHexadecimalString(spanId)}-0${
+          traceparent: `00-${traceId.toHexString().padStart(32, '0')}-${toPaddedHexadecimalString(spanId)}-0${
             traceSampled ? '1' : '0'
           }`,
           tracestate: `dd=s:${traceSampled ? '1' : '0'};o:rum`,
@@ -207,13 +213,13 @@ function makeTracingHeaders(
       // https://github.com/openzipkin/b3-propagation
       case 'b3': {
         Object.assign(tracingHeaders, {
-          b3: `${toPaddedHexadecimalString(traceId)}-${toPaddedHexadecimalString(spanId)}-${traceSampled ? '1' : '0'}`,
+          b3: `${traceId.toHexString()}-${toPaddedHexadecimalString(spanId)}-${traceSampled ? '1' : '0'}`,
         })
         break
       }
       case 'b3multi': {
         Object.assign(tracingHeaders, {
-          'X-B3-TraceId': toPaddedHexadecimalString(traceId),
+          'X-B3-TraceId': traceId.toHexString(),
           'X-B3-SpanId': toPaddedHexadecimalString(spanId),
           'X-B3-Sampled': traceSampled ? '1' : '0',
         })

--- a/test/e2e/lib/framework/serverApps/mock.ts
+++ b/test/e2e/lib/framework/serverApps/mock.ts
@@ -22,6 +22,30 @@ export function createMockServerApp(servers: Servers, setup: string, setupOption
 
   const { webSocketUrl, handleUpgrade, closeEchoWebSockets } = setupEchoWebSockets(servers.base.origin)
 
+  app.use(['/restricted-cors-headers', '/restricted-cors-headers-with-tags'], (req, res, next) => {
+    const allowedHeaders = [
+      'baggage',
+      'traceparent',
+      'tracestate',
+      'x-datadog-origin',
+      'x-datadog-parent-id',
+      'x-datadog-sampling-priority',
+      'x-datadog-trace-id',
+    ]
+    if (req.originalUrl.startsWith('/restricted-cors-headers-with-tags')) {
+      allowedHeaders.push('x-datadog-tags')
+    }
+
+    res.header('Access-Control-Allow-Origin', '*')
+    res.header('Access-Control-Allow-Methods', 'GET, OPTIONS')
+    res.header('Access-Control-Allow-Headers', allowedHeaders.join(', '))
+    if (req.method === 'OPTIONS') {
+      res.status(204).end()
+      return
+    }
+    next()
+  })
+
   app.use(cors())
   app.disable('etag') // disable automatic resource caching
 
@@ -172,6 +196,10 @@ export function createMockServerApp(servers: Servers, setup: string, setupOption
   })
 
   app.get('/headers', (req, res) => {
+    res.send(JSON.stringify(req.headers))
+  })
+
+  app.get(['/restricted-cors-headers', '/restricted-cors-headers-with-tags'], (req, res) => {
     res.send(JSON.stringify(req.headers))
   })
 

--- a/test/e2e/scenario/rum/tracing.scenario.ts
+++ b/test/e2e/scenario/rum/tracing.scenario.ts
@@ -38,6 +38,25 @@ test.describe('tracing', () => {
       checkTraceAssociatedToRumEvent(intakeRegistry)
     })
 
+  createTest('trace fetch with a 128-bit trace id')
+    .withRum({
+      service: 'service',
+      allowedTracingUrls: ['LOCATION_ORIGIN'],
+      enableExperimentalFeatures: ['trace_id_128_bit'],
+    })
+    .run(async ({ intakeRegistry, flushEvents, page }) => {
+      const rawHeaders = await page.evaluate(() =>
+        window
+          .fetch('/headers')
+          .then((response) => response.text())
+          .catch(() => new Error('Fetch request failed!'))
+      )
+      const headers = parseHeaders(rawHeaders)
+      const fullTraceId = check128BitRequestHeaders(headers)
+      await flushEvents()
+      checkTraceAssociatedToRumEvent(intakeRegistry, fullTraceId)
+    })
+
   createTest('trace fetch with Request argument')
     .withRum({ service: 'service', allowedTracingUrls: ['LOCATION_ORIGIN'] })
     .run(async ({ intakeRegistry, flushEvents, page }) => {
@@ -113,6 +132,66 @@ test.describe('tracing', () => {
       checkTraceAssociatedToRumEvent(intakeRegistry)
     })
 
+  createTest('trace a cross-origin request with a 128-bit trace id')
+    .withRum({
+      service: 'service',
+      allowedTracingUrls: [(url) => url.includes('/restricted-cors-headers-with-tags')],
+      enableExperimentalFeatures: ['trace_id_128_bit'],
+    })
+    .run(async ({ servers, intakeRegistry, sendXhr, flushEvents }) => {
+      const rawHeaders = await sendXhr(`${servers.crossOrigin.origin}/restricted-cors-headers-with-tags`)
+      const headers = parseHeaders(rawHeaders)
+      const fullTraceId = check128BitRequestHeaders(headers)
+      await flushEvents()
+      checkTraceAssociatedToRumEvent(intakeRegistry, fullTraceId)
+    })
+
+  createTest('reject a cross-origin 128-bit Datadog trace when x-datadog-tags is not allowed')
+    .withRum({
+      service: 'service',
+      allowedTracingUrls: [(url) => url.includes('/restricted-cors-headers')],
+      enableExperimentalFeatures: ['trace_id_128_bit'],
+    })
+    .run(async ({ servers, sendXhr, withBrowserLogs }) => {
+      await expect(sendXhr(`${servers.crossOrigin.origin}/restricted-cors-headers`)).rejects.toThrow()
+      withBrowserLogs((logs) => {
+        expect(logs.some((log) => log.level === 'error' && log.message.includes('x-datadog-tags'))).toBe(true)
+      })
+    })
+
+  createTest('trace a cross-origin 64-bit request with the legacy CORS allowlist')
+    .withRum({
+      service: 'service',
+      allowedTracingUrls: [(url) => url.includes('/restricted-cors-headers')],
+    })
+    .run(async ({ servers, intakeRegistry, sendXhr, flushEvents }) => {
+      const rawHeaders = await sendXhr(`${servers.crossOrigin.origin}/restricted-cors-headers`)
+      const headers = parseHeaders(rawHeaders)
+      checkRequestHeaders(headers)
+      expect(headers['x-datadog-tags']).toBeUndefined()
+      await flushEvents()
+      checkTraceAssociatedToRumEvent(intakeRegistry)
+    })
+
+  createTest('trace a cross-origin 128-bit tracecontext request without x-datadog-tags')
+    .withRum({
+      service: 'service',
+      allowedTracingUrls: [
+        { match: (url: string) => url.includes('/restricted-cors-headers'), propagatorTypes: ['tracecontext'] },
+      ],
+      enableExperimentalFeatures: ['trace_id_128_bit'],
+    })
+    .run(async ({ servers, intakeRegistry, sendXhr, flushEvents }) => {
+      const rawHeaders = await sendXhr(`${servers.crossOrigin.origin}/restricted-cors-headers`)
+      const headers = parseHeaders(rawHeaders)
+      expect(headers['x-datadog-trace-id']).toBeUndefined()
+      expect(headers['x-datadog-tags']).toBeUndefined()
+      const fullTraceId = headers['traceparent'].split('-')[1]
+      expect(fullTraceId).toMatch(/^[0-9a-f]{8}00000000[0-9a-f]{16}$/)
+      await flushEvents()
+      checkTraceAssociatedToRumEvent(intakeRegistry, fullTraceId)
+    })
+
   interface ParsedHeaders {
     [key: string]: string
   }
@@ -142,12 +221,27 @@ test.describe('tracing', () => {
     }
   }
 
-  function checkTraceAssociatedToRumEvent(intakeRegistry: IntakeRegistry) {
+  function check128BitRequestHeaders(headers: ParsedHeaders): string {
+    const fullTraceId = headers['traceparent'].split('-')[1]
+    const highTraceId = fullTraceId.slice(0, 16)
+    const lowTraceId = fullTraceId.slice(16)
+
+    expect(fullTraceId).toMatch(/^[0-9a-f]{8}00000000[0-9a-f]{16}$/)
+    expect(headers['x-datadog-tags']).toBe(`_dd.p.tid=${highTraceId}`)
+    expect(BigInt(headers['x-datadog-trace-id']).toString(16).padStart(16, '0')).toBe(lowTraceId)
+    return fullTraceId
+  }
+
+  function checkTraceAssociatedToRumEvent(intakeRegistry: IntakeRegistry, expectedTraceId?: string) {
     const requests = intakeRegistry.rumResourceEvents.filter(
       (event) => event.resource.type === 'xhr' || event.resource.type === 'fetch'
     )
     expect(requests).toHaveLength(1)
-    expect(requests[0]._dd.trace_id).toMatch(/\d+/)
+    if (expectedTraceId) {
+      expect(requests[0]._dd.trace_id).toBe(expectedTraceId)
+    } else {
+      expect(requests[0]._dd.trace_id).toMatch(/\d+/)
+    }
     expect(requests[0]._dd.span_id).toMatch(/\d+/)
     expect(requests[0].resource.id).toBeDefined()
   }


### PR DESCRIPTION
Draft: waiting for approval on the [RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/7027065934/RFC+-+Browser+SDK+128+bit+trace+ID).

## Motivation

Browser RUM currently generates 64-bit trace IDs and stores them as decimal on resource events. APM, mobile SDKs, and LLM Observability use 128-bit hexadecimal IDs, so Browser-started traces cannot be joined through one shared representation without extracting the low 64 bits and converting it to hexadecimal.

This PR introduces 128-bit trace IDs behind the `trace_id_128_bit` experimental feature. The existing 64-bit behavior remains the default while we dogfood and validate end-to-end correlation and CORS behavior.

## Changes

- Generate trace IDs using `<32-bit Unix timestamp><32 zero bits><64 random bits>`.
- Add explicit low-decimal, full-hex, and high-hex identifier representations while preserving the existing `toString()` behavior.
- When `trace_id_128_bit` is enabled:
  - keep `x-datadog-trace-id` as the low 64 bits in decimal;
  - add `x-datadog-tags: _dd.p.tid=<high 64 bits in hex>`;
  - send the full 128-bit hexadecimal ID in W3C `traceparent`, B3, and B3 multi headers;
  - store `_dd.trace_id` on RUM resource events as a 32-character lowercase hexadecimal string.
- Keep span ID generation and session-consistent trace sampling unchanged; sampling still uses the low 64 bits.
- Add restricted-CORS E2E coverage for the new `x-datadog-tags` header and the tracecontext-only fallback.

Enable it with:

```js
DD_RUM.init({
  // ...
  enableExperimentalFeatures: ['trace_id_128_bit'],
})
```

Example from manual testing:

| Representation | Value |
| --- | --- |
| Full trace ID, 128-bit hex | `6a6ca9f1000000000d5e267e2ee09948` |
| High 64 bits, hex (`_dd.p.tid`) | `6a6ca9f100000000` |
| Low 64 bits, decimal (`x-datadog-trace-id`) | `963249693698070856` |
| Span ID, decimal | `6901709716850828458` |

The full trace ID is the concatenation of the high 64-bit hex value and the low 64 bits converted to 16-character hexadecimal.

[Playground](https://datadoghq.dev/browser-sdk-test-playground/?client_token=pub2ad3fe2578f01b9f329bd0ea4a2f08c5&application_id=1397744d-34f4-4a6a-a735-801e31c18221&site=datadoghq.com&service=browser-sdk-128bit-local&enable-tracing) 

Screenshots:
<img width="1162" height="199" alt="Screenshot 2026-07-31 at 16 14 19" src="https://github.com/user-attachments/assets/6c23a72f-bb6f-496b-a761-b41c437c7dd2" />

<img width="1063" height="524" alt="Screenshot 2026-07-31 at 16 14 30" src="https://github.com/user-attachments/assets/fa181bf1-c424-46be-9035-f53b68b74e54" />

<img width="462" height="834" alt="Screenshot 2026-07-31 at 16 14 40" src="https://github.com/user-attachments/assets/ada49c8d-5d00-4652-b169-7ac45ea3103a" />

link of the example trace in [DD](https://app.datadoghq.com/rum/sessions?query=%40type%3Aresource%20%40application.id%3A1397744d-34f4-4a6a-a735-801e31c18221&agg_m=count&agg_m_source=base&agg_t=count&event=AwAAAZ-4d9elCsj5BQAAABhBWi00ZUQ4d0FBQ3d6eFAxRThaSHZRQUIAAAAkZjE5ZmI4NzktNTNmYy00MzhkLWFmNWQtYzQ0YjY2MzdlZTA5AAVPqw&fromUser=false&graphType=flamegraph&refresh_mode=sliding&shouldShowLegend=true&sort_by=&sort_order=&spanID=4304905340565122271&traceQuery=&viz=stream&from_ts=1785422905784&to_ts=1785509305784&live=true)


## Test instructions

1. Build and serve the local Browser SDK, then override the [Playground](https://datadoghq.dev/browser-sdk-test-playground/?client_token=pub2ad3fe2578f01b9f329bd0ea4a2f08c5&application_id=1397744d-34f4-4a6a-a735-801e31c18221&site=datadoghq.com&service=browser-sdk-128bit-local&enable-tracing) SDK with the developer extension.
2. Initialize RUM with:

   ```json
   {
     "applicationId": "<application-id>",
     "clientToken": "<client-token>",
     "site": "datadoghq.com",
     "service": "browser-sdk-128bit-local",
     "allowedTracingUrls": ["https://datadoghq.dev"],
     "enableExperimentalFeatures": ["trace_id_128_bit"]
   }
   ```

3. Trigger a traced fetch or XHR request.
4. Verify that:
   - `traceparent` contains a non-zero 32-character trace ID;
   - `x-datadog-tags` contains `_dd.p.tid` matching the first 16 characters of `traceparent`;
   - `x-datadog-trace-id` remains a decimal representation of the low 64 bits;
   - the RUM resource event stores the same full trace ID as 32-character hexadecimal.
5. For cross-origin Datadog propagation, allow `x-datadog-tags` in `Access-Control-Allow-Headers`; otherwise the browser preflight is expected to fail.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
