### PR TITLE
✨ [RUM-17934] support arbitrary custom url protocols in stack trace parsing

### DIFF
--- a/packages/browser-core/src/tools/stackTrace/capturedExceptions.specHelper.ts
+++ b/packages/browser-core/src/tools/stackTrace/capturedExceptions.specHelper.ts
@@ -46,6 +46,22 @@ export const ELECTRON = {
     at I.e.fn.(anonymous function) [as index] (electron://-/file.js:10:3651)`,
 }
 
+export const CUSTOM_PROTOCOL_APP = {
+  message: 'Custom protocol error',
+  name: 'Error',
+  stack: `Error: Custom protocol error
+    at dumpExceptionError (app://renderer/file.js:41:27)
+    at HTMLButtonElement.onclick (app://renderer/file.js:107:146)
+    at I.e.fn.(anonymous function) [as index] (app://renderer/file.js:10:3651)`,
+}
+
+export const CUSTOM_PROTOCOL_SPECIAL_CHARS = {
+  message: 'Custom protocol error',
+  name: 'Error',
+  stack: `Error: Custom protocol error
+    at dumpExceptionError (my-app+v2.beta://renderer/file.js:12:5)`,
+}
+
 export const FIREFOX_3 = {
   fileName: 'http://127.0.0.1:8000/js/stacktrace.js',
   lineNumber: 44,

--- a/packages/browser-core/src/tools/stackTrace/computeStackTrace.spec.ts
+++ b/packages/browser-core/src/tools/stackTrace/computeStackTrace.spec.ts
@@ -564,6 +564,46 @@ Error: foo
     })
   })
 
+  it('should parse an arbitrary custom protocol schema with Chrome error', () => {
+    const stackFrames = computeStackTrace(CapturedExceptions.CUSTOM_PROTOCOL_APP)
+
+    expect(stackFrames.stack.length).toEqual(3)
+    expect(stackFrames.stack[0]).toEqual({
+      args: [],
+      column: 27,
+      func: 'dumpExceptionError',
+      line: 41,
+      url: 'app://renderer/file.js',
+    })
+    expect(stackFrames.stack[1]).toEqual({
+      args: [],
+      column: 146,
+      func: 'HTMLButtonElement.onclick',
+      line: 107,
+      url: 'app://renderer/file.js',
+    })
+    expect(stackFrames.stack[2]).toEqual({
+      args: [],
+      column: 3651,
+      func: 'I.e.fn.(anonymous function) [as index]',
+      line: 10,
+      url: 'app://renderer/file.js',
+    })
+  })
+
+  it('should parse a custom protocol scheme containing +, -, . characters', () => {
+    const stackFrames = computeStackTrace(CapturedExceptions.CUSTOM_PROTOCOL_SPECIAL_CHARS)
+
+    expect(stackFrames.stack.length).toEqual(1)
+    expect(stackFrames.stack[0]).toEqual({
+      args: [],
+      column: 5,
+      func: 'dumpExceptionError',
+      line: 12,
+      url: 'my-app+v2.beta://renderer/file.js',
+    })
+  })
+
   it('should parse nested eval() from Chrome', () => {
     const stackFrames = computeStackTrace(CapturedExceptions.CHROME_48_EVAL)
 

--- a/packages/browser-core/src/tools/stackTrace/computeStackTrace.ts
+++ b/packages/browser-core/src/tools/stackTrace/computeStackTrace.ts
@@ -79,8 +79,7 @@ export function computeStackTrace(ex: unknown): StackTrace {
     stack,
   }
 }
-const fileUrl =
-  '((?:file|https?|blob|chrome-extension|electron|native|eval|webpack|snippet|<anonymous>|\\w+\\.|\\/).*?)'
+const fileUrl = '((?:blob|native|eval|<anonymous>|[a-zA-Z][a-zA-Z0-9+.-]*:\\/\\/|\\w+\\.|\\/).*?)'
 const filePosition = '(?::(\\d+))'
 const CHROME_LINE_RE = new RegExp(`^\\s*at (.*?) ?\\(${fileUrl}${filePosition}?${filePosition}?\\)?\\s*$`, 'i')
 


### PR DESCRIPTION

## Motivation

Electron renderer processes can serve their content over an arbitrary custom URL scheme (e.g. `app://`). `computeStackTrace`'s Chrome-style parser only recognized a hard-coded allowlist of protocol prefixes, so stack frames using an unlisted scheme failed to parse correctly, breaking source-map/debug-id linking and RUM service/version attribution. Reported via a sample Electron app using `app://` (RUM-17934).

## Changes

- Replace the hard-coded protocol allowlist in the Chrome-style stack-frame regex with one generic pattern matching any [RFC 3986 / WHATWG-compliant URL scheme](https://datatracker.ietf.org/doc/html/rfc3986#section-3) (`[a-zA-Z][a-zA-Z0-9+.-]*://`), the same grammar Electron's own `protocol.registerSchemesAsPrivileged` follows ([doc](https://www.electronjs.org/docs/latest/api/protocol#protocolregisterschemesasprivilegedcustomschemes)).
- Kept the few literals that aren't plain `scheme://` URLs (`blob`, `native`, `eval`, `<anonymous>`) unchanged.

## Test instructions

To validate against a real Electron app:
1. Register a custom protocol scheme (e.g. `app://`) as the renderer's origin
2. Throw an error from renderer code so its stack trace includes `app://...` frames
3. Confirm the SDK's captured error event includes the full stack with correct `url`/`line`/`column` per frame (previously dropped or corrupted) and that source-map/debug-id linking resolves for those frames

[Before:](https://app.datadoghq.com/rum/sessions?query=%40type%3Aerror%20%40application.id%3A0f574f27-317e-4223-b5b6-c935b4c83700%20%40session.id%3A94735649-99a4-4628-99f4-d45e7a262690&agg_m=count&agg_m_source=base&agg_t=count&event=AwAAAZ_XYY6oEpj4KQAAABhBWl9YWXVIT0FBQU5ucFVtdXUzZnlnQUEAAAAkZjE5ZmQ3NjMtYWVkNi00MTJkLWFmOTYtMjFkNGM1MTQ4YzA4AAbEzg&fromUser=false&refresh_mode=sliding&sort_by=&sort_order=&viz=stream&from_ts=1786022183733&to_ts=1786025783733&live=true)
<img width="655" height="146" alt="Screenshot 2026-08-06 at 16 19 05" src="https://github.com/user-attachments/assets/63075836-5cf5-4861-a617-a7e2ab7f86a3" />


[After:](https://app.datadoghq.com/rum/sessions?query=%40type%3Aerror%20%40application.id%3A0f574f27-317e-4223-b5b6-c935b4c83700%20%40session.id%3A93da38cc-6644-4077-9e6e-df76f7031c56&agg_m=count&agg_m_source=base&agg_t=count&event=AwAAAZ_XbZl7BmNOlQAAABhBWl9YYmE5T0FBQUpkTFpVYWxoamZBQUUAAAAkMDE5ZmQ3NmQtYzkyYi00MWU4LTkwZGItZWE5YjFhZWEwYzJkAAAEYg&fromUser=false&refresh_mode=sliding&sort_by=&sort_order=&viz=stream&from_ts=1786022180419&to_ts=1786025780419&live=true)
<img width="563" height="163" alt="Screenshot 2026-08-06 at 16 18 07" src="https://github.com/user-attachments/assets/1be687fb-6cfd-4e2f-ab5d-bc220b9f7cd2" />


## Checklist

- [x] Tested locally <!-- check after manual testing -->
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file