### PR TITLE
📝 Fix propagateTraceBaggage TSDoc @defaultValue (false → true)

### DIFF
--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -77,7 +77,7 @@ export interface RumInitConfiguration extends InitConfiguration {
    * Whether to propagate user and account IDs in the baggage header of trace requests.
    *
    * @category Tracing
-   * @defaultValue false
+   * @defaultValue true
    */
   propagateTraceBaggage?: boolean | undefined
 


### PR DESCRIPTION
## Motivation

The TSDoc `@defaultValue` for `propagateTraceBaggage` currently says `false`, but the actual default has been `true` since v7 (#4226 flipped the runtime default but did not update the doc comment).

This is confirmed by Datadog's own public v7 migration guide, which documents the default as `true` and its CORS implication:

> "The `propagateTraceBaggage` initialization parameter defaults to `true` in v7... If you use distributed tracing on cross-origin requests, either set `propagateTraceBaggage: false` or add `baggage` to your `Access-Control-Allow-Headers` response headers: `Access-Control-Allow-Headers: traceparent, tracestate, baggage`"

[Upgrade the RUM Browser SDK](https://docs.datadoghq.com/real_user_monitoring/guide/browser-sdk-upgrade/)

The stale TSDoc contradicts this public documentation. Integrators who rely on the generated `.d.ts` / IDE autocomplete instead of reading the migration guide have no way to know the real default. This was surfaced via a customer support ticket.

## Changes

One-line JSDoc fix in `packages/browser-rum-core/src/domain/configuration/configuration.ts`:

```diff
 /**
  * Whether to propagate user and account IDs in the baggage header of trace requests.
  *
  * @category Tracing
- * @defaultValue false
+ * @defaultValue true
  */
 propagateTraceBaggage?: boolean | undefined
```

No behavior change. Affects only the generated type declarations (`.d.ts`) shipped in future npm releases.

## Test instructions

N/A, documentation-only change with no runtime behavior affected. The `true` default is already in effect via the existing default-resolution logic (`propagateTraceBaggage: initConfiguration.propagateTraceBaggage !== false`, unchanged since #4226).

## Checklist

- [ ] Tested locally — n/a, doc comment only
- [ ] Tested on staging — n/a
- [ ] Added unit tests for this change. — n/a, no behavior change
- [ ] Added e2e/integration tests for this change. — n/a
- [x] Updated documentation and/or relevant AGENTS.md file — this PR is the doc fix itself