### PR TITLE
🐛 Report CDN bundles as CDN SDK setup

### DIFF
--- a/developer-extension/wxt.config.ts
+++ b/developer-extension/wxt.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'wxt'
-import { getBuildEnvValue } from '../scripts/lib/buildEnv'
+import { getBuildEnvDefines } from '../scripts/lib/buildEnv'
 
 // eslint-disable-next-line import-x/no-default-export
 export default defineConfig({
@@ -38,8 +38,6 @@ export default defineConfig({
         generateScopedName: '[name]_[local]_[hash:base64:5]',
       },
     },
-    define: {
-      __BUILD_ENV__SDK_VERSION__: JSON.stringify(getBuildEnvValue('SDK_VERSION')),
-    },
+    define: getBuildEnvDefines({ setup: 'npm' }),
   }),
 })

--- a/packages/browser-core/test/buildEnv.ts
+++ b/packages/browser-core/test/buildEnv.ts
@@ -1,4 +1,0 @@
-// to simulate different build env behavior
-export interface BuildEnvWindow {
-  __BUILD_ENV__SDK_VERSION__: string
-}

--- a/packages/browser-core/test/forEach.spec.ts
+++ b/packages/browser-core/test/forEach.spec.ts
@@ -13,8 +13,6 @@ import { resetTelemetry } from '../src/domain/telemetry'
 import { resetSampleDecisionCache } from '../src/domain/sampler'
 import { resetAllowUntrustedEvents } from '../src/browser/addEventListener'
 import { startLeakDetection } from './leakDetection'
-import type { BuildEnvWindow } from './buildEnv'
-;(window as unknown as BuildEnvWindow).__BUILD_ENV__SDK_VERSION__ = 'test'
 ;(window as any).IS_REACT_ACT_ENVIRONMENT = true
 
 beforeEach(() => {

--- a/packages/browser-core/test/index.ts
+++ b/packages/browser-core/test/index.ts
@@ -1,6 +1,5 @@
 export * from './browserChecks'
 export * from './browserExtension'
-export type * from './buildEnv'
 export * from './collectAsyncCalls'
 export * from './cookie'
 export * from './registerCleanupTask'

--- a/packages/browser-rum-shopify/package.json
+++ b/packages/browser-rum-shopify/package.json
@@ -14,8 +14,8 @@
     "!src/**/*.specHelper.ts"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/build-package.ts --modules --bundle datadog-rum-shopify.js",
-    "build:bundle": "node ../../scripts/build/build-package.ts --bundle datadog-rum-shopify.js",
+    "build": "node ../../scripts/build/build-package.ts --modules --worker-string --bundle datadog-rum-shopify.js",
+    "build:bundle": "node ../../scripts/build/build-package.ts --worker-string --bundle datadog-rum-shopify.js",
     "prepack": "yarn build"
   },
   "dependencies": {

--- a/packages/browser-rum/package.json
+++ b/packages/browser-rum/package.json
@@ -16,8 +16,8 @@
     "!src/**/*.specHelper.ts"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/build-package.ts --modules --bundle datadog-rum.js",
-    "build:bundle": "node ../../scripts/build/build-package.ts --bundle datadog-rum.js",
+    "build": "node ../../scripts/build/build-package.ts --modules --worker-string --bundle datadog-rum.js",
+    "build:bundle": "node ../../scripts/build/build-package.ts --worker-string --bundle datadog-rum.js",
     "prepack": "yarn build"
   },
   "dependencies": {

--- a/scripts/build/build-package.ts
+++ b/scripts/build/build-package.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs/promises'
-import { readFileSync, globSync } from 'node:fs'
 import { parseArgs } from 'node:util'
 import ts from 'typescript'
 import webpack from 'webpack'
@@ -7,7 +6,7 @@ import { build as tsdownBuild } from 'tsdown'
 import webpackBase from '../../webpack.base.ts'
 
 import { printLog, runMain } from '../lib/executionUtils.ts'
-import { buildEnvKeys, getBuildEnvValue } from '../lib/buildEnv.ts'
+import { getBuildEnvDefines } from '../lib/buildEnv.ts'
 
 runMain(async () => {
   const { values } = parseArgs({
@@ -19,6 +18,10 @@ runMain(async () => {
         type: 'string',
         multiple: true,
       },
+      'worker-string': {
+        type: 'boolean',
+        default: false,
+      },
       verbose: {
         type: 'boolean',
         default: false,
@@ -28,12 +31,16 @@ runMain(async () => {
 
   if (values.modules) {
     printLog('Building modules...')
-    await buildModules({ verbose: values.verbose })
+    await buildModules({ verbose: values.verbose, includeWorkerString: values['worker-string'] })
   }
 
   if (values.bundle?.length) {
     printLog('Building bundle...')
-    await buildBundles({ bundles: values.bundle.map(parseBundleOption), verbose: values.verbose })
+    await buildBundles({
+      bundles: values.bundle.map(parseBundleOption),
+      verbose: values.verbose,
+      includeWorkerString: values['worker-string'],
+    })
   }
 
   printLog('Done.')
@@ -55,7 +62,15 @@ function parseBundleOption(bundle: string): Bundle {
   }
 }
 
-async function buildBundles({ bundles, verbose }: { bundles: Bundle[]; verbose: boolean }) {
+async function buildBundles({
+  bundles,
+  verbose,
+  includeWorkerString,
+}: {
+  bundles: Bundle[]
+  verbose: boolean
+  includeWorkerString: boolean
+}) {
   await fs.rm('./bundle', { recursive: true, force: true })
   await Promise.all(bundles.map(buildBundle))
 
@@ -66,6 +81,7 @@ async function buildBundles({ bundles, verbose }: { bundles: Bundle[]; verbose: 
           mode: 'production',
           entry,
           filename,
+          includeWorkerString,
         }),
         (error, stats) => {
           if (error) {
@@ -91,19 +107,7 @@ async function buildBundles({ bundles, verbose }: { bundles: Bundle[]; verbose: 
   }
 }
 
-// Returns only the build-env keys actually referenced in this package's sources. tsdown's `define`
-// is eager: every listed key is computed up front, for every package. WORKER_STRING reads (and may
-// rebuild) packages/browser-worker/bundle/worker.js, so computing it for packages that don't use it
-// makes them race against browser-worker's own concurrent rebuild. Filtering to referenced keys
-// mirrors webpack's lazy DefinePlugin.runtimeValue, so only browser-rum (the sole consumer) touches
-// the worker bundle.
-function referencedBuildEnvKeys() {
-  const files = globSync('./src/**/*.ts', { exclude: ['**/*.spec.*', '**/*.specHelper.*'] })
-  const content = files.map((file) => readFileSync(file, 'utf8')).join('\n')
-  return buildEnvKeys.filter((key) => content.includes(`__BUILD_ENV__${key}__`))
-}
-
-async function buildModules({ verbose }: { verbose: boolean }) {
+async function buildModules({ verbose, includeWorkerString }: { verbose: boolean; includeWorkerString: boolean }) {
   // Transpile the source with tsdown (Rolldown). We let TypeScript emit the declaration files (see
   // emitDeclarations) rather than tsdown, because Rolldown's declaration bundler restructures
   // modules in ways that break compatibility with older TypeScript versions (e.g. inline `type`
@@ -134,9 +138,10 @@ async function buildModules({ verbose }: { verbose: boolean }) {
     unbundle: true,
     dts: false,
     tsconfig: '../../tsconfig.base.json',
-    define: Object.fromEntries(
-      referencedBuildEnvKeys().map((key) => [`__BUILD_ENV__${key}__`, JSON.stringify(getBuildEnvValue(key))])
-    ),
+    define: getBuildEnvDefines({
+      setup: 'npm',
+      workerString: includeWorkerString,
+    }),
     sourcemap: true,
     logLevel: verbose ? 'info' : 'error',
   })

--- a/scripts/deploy/upload-source-maps.ts
+++ b/scripts/deploy/upload-source-maps.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { printLog, runMain } from '../lib/executionUtils.ts'
 import { command } from '../lib/command.ts'
-import { getBuildEnvValue } from '../lib/buildEnv.ts'
+import { getBuildEnvSdkVersion } from '../lib/buildEnv.ts'
 import { getTelemetryOrgApiKey, getOrg2ApiKey } from '../lib/secrets.ts'
 import { getAllDatacentersMetadata, getDatacenterMetadata } from '../lib/datacenter.ts'
 import { forEachFile } from '../lib/filesUtils.ts'
@@ -97,7 +97,7 @@ function uploadToOrg2(packageName: string, service: string, prefix: string, bund
   command`
     datadog-ci sourcemaps upload ${bundleFolder}
       --service ${service}
-      --release-version ${getBuildEnvValue('SDK_VERSION')}
+      --release-version ${getBuildEnvSdkVersion()}
       --minified-path-prefix ${org2Prefix}
       --project-path @datadog/${packageName}/
       --repository-url https://www.github.com/datadog/browser-sdk
@@ -129,7 +129,7 @@ function uploadToDatadog(
     command`
       datadog-ci sourcemaps upload ${bundleFolder}
         --service ${service}
-        --release-version ${getBuildEnvValue('SDK_VERSION')}
+        --release-version ${getBuildEnvSdkVersion()}
         --minified-path-prefix ${prefix}
         --project-path @datadog/${packageName}/
         --repository-url https://www.github.com/datadog/browser-sdk

--- a/scripts/dev-server/lib/server.ts
+++ b/scripts/dev-server/lib/server.ts
@@ -93,7 +93,7 @@ function createStaticSandboxApp(): express.Application {
             entry: `${packagePath}/src/entries/main.ts`,
             filename:
               packageName === 'browser-worker' ? 'worker.js' : `${packageName.replace(/^browser-/, 'datadog-')}.js`,
-            includeWorkerString: packageName === 'browser-rum',
+            includeWorkerString: packageName === 'browser-rum' || packageName === 'browser-rum-shopify',
           })
         ),
         { stats: 'minimal' }
@@ -132,6 +132,7 @@ function createReactApp(): express.Application {
           entry: `${sandboxPath}/react-app/main.tsx`,
           plugins: [new HtmlWebpackPlugin({ publicPath: '/react-app/' })],
           mode: 'development',
+          includeWorkerString: true,
         })
       ),
       { stats: 'minimal' }

--- a/scripts/dev-server/lib/server.ts
+++ b/scripts/dev-server/lib/server.ts
@@ -93,6 +93,7 @@ function createStaticSandboxApp(): express.Application {
             entry: `${packagePath}/src/entries/main.ts`,
             filename:
               packageName === 'browser-worker' ? 'worker.js' : `${packageName.replace(/^browser-/, 'datadog-')}.js`,
+            includeWorkerString: packageName === 'browser-rum',
           })
         ),
         { stats: 'minimal' }

--- a/scripts/lib/buildEnv.ts
+++ b/scripts/lib/buildEnv.ts
@@ -5,7 +5,6 @@ import { browserSdkVersion } from './browserSdkVersion.ts'
 import { command } from './command.ts'
 
 type BuildMode = 'dev' | 'release' | 'canary'
-type SdkSetup = 'npm' | 'cdn'
 
 /**
  * Allows to define which sdk_version to send to the intake.
@@ -19,54 +18,46 @@ const BUILD_MODES: BuildMode[] = [
   'canary',
 ]
 
-/**
- * Allows to define which sdk setup to send to the telemetry.
- */
-const SDK_SETUPS: SdkSetup[] = ['npm', 'cdn']
-
 const WORKER_PATH = path.join(import.meta.dirname, '../../packages/browser-worker')
 
-const buildEnvCache = new Map<string, string>()
-
-type BuildEnvFactories = {
-  [K in 'SDK_VERSION' | 'SDK_SETUP' | 'WORKER_STRING']: () => string
-}
-
-const buildEnvFactories: BuildEnvFactories = {
-  SDK_VERSION: () => {
-    switch (getBuildMode()) {
-      case 'release':
-        return browserSdkVersion
-      case 'canary': {
-        const commitSha1 = execSync('git rev-parse HEAD').toString().trim()
-        // TODO when tags would allow '+' characters
-        //  use build separator (+) instead of prerelease separator (-)
-        return `${browserSdkVersion}-${commitSha1}`
-      }
-      default:
-        return 'dev'
-    }
-  },
-  SDK_SETUP: () => getSdkSetup(),
-  WORKER_STRING: () => {
-    if (needsWorkerRebuild()) {
-      command`yarn build`.withCurrentWorkingDirectory(WORKER_PATH).run()
-    }
-    return fs.readFileSync(path.join(WORKER_PATH, 'bundle/worker.js'), {
-      encoding: 'utf-8',
-    })
-  },
-}
-
-export const buildEnvKeys = Object.keys(buildEnvFactories) as Array<keyof BuildEnvFactories>
-
-export function getBuildEnvValue(key: keyof BuildEnvFactories): string {
-  let value = buildEnvCache.get(key)
-  if (!value) {
-    value = buildEnvFactories[key]()
-    buildEnvCache.set(key, value)
+export function getBuildEnvDefines({
+  setup,
+  version = getBuildEnvSdkVersion(),
+  workerString = false,
+}: {
+  setup: 'npm' | 'cdn'
+  version?: string
+  workerString?: boolean
+}): Record<string, string> {
+  return {
+    __BUILD_ENV__SDK_VERSION__: JSON.stringify(version),
+    __BUILD_ENV__SDK_SETUP__: JSON.stringify(setup),
+    ...(workerString && { __BUILD_ENV__WORKER_STRING__: JSON.stringify(getWorkerString()) }),
   }
-  return value
+}
+
+export function getBuildEnvSdkVersion(): string {
+  switch (getBuildMode()) {
+    case 'release':
+      return browserSdkVersion
+    case 'canary': {
+      const commitSha1 = execSync('git rev-parse HEAD').toString().trim()
+      // TODO when tags would allow '+' characters
+      //  use build separator (+) instead of prerelease separator (-)
+      return `${browserSdkVersion}-${commitSha1}`
+    }
+    default:
+      return 'dev'
+  }
+}
+
+function getWorkerString(): string {
+  if (needsWorkerRebuild()) {
+    command`yarn build`.withCurrentWorkingDirectory(WORKER_PATH).run()
+  }
+  return fs.readFileSync(path.join(WORKER_PATH, 'bundle/worker.js'), {
+    encoding: 'utf-8',
+  })
 }
 
 function getBuildMode(): BuildMode {
@@ -77,17 +68,6 @@ function getBuildMode(): BuildMode {
     return process.env.BUILD_MODE as BuildMode
   }
   console.log(`Invalid build mode "${process.env.BUILD_MODE}". Possible build modes are: ${BUILD_MODES.join(', ')}`)
-  process.exit(1)
-}
-
-function getSdkSetup(): SdkSetup {
-  if (!process.env.SDK_SETUP) {
-    return SDK_SETUPS[0] // npm
-  }
-  if (SDK_SETUPS.includes(process.env.SDK_SETUP as SdkSetup)) {
-    return process.env.SDK_SETUP as SdkSetup
-  }
-  console.log(`Invalid SDK setup "${process.env.SDK_SETUP}". Possible SDK setups are: ${SDK_SETUPS.join(', ')}`)
   process.exit(1)
 }
 

--- a/test/e2e/scenario/telemetry.scenario.ts
+++ b/test/e2e/scenario/telemetry.scenario.ts
@@ -1,7 +1,21 @@
 import { test, expect } from '@playwright/test'
-import { createTest, html } from '../lib/framework'
+import { bundleSetup, createTest, html, npmSetup } from '../lib/framework'
 
 test.describe('telemetry', () => {
+  for (const { name, setup, expectedSdkSetup } of [
+    { name: 'bundle', setup: bundleSetup, expectedSdkSetup: 'cdn' },
+    { name: 'npm', setup: npmSetup, expectedSdkSetup: 'npm' },
+  ]) {
+    createTest(`reports the SDK setup for ${name}`)
+      .withSetup(setup)
+      .withRum()
+      .run(async ({ intakeRegistry, flushEvents }) => {
+        await flushEvents()
+        const event = intakeRegistry.telemetryConfigurationEvents[0]
+        expect(event.telemetry.sdk_setup).toBe(expectedSdkSetup)
+      })
+  }
+
   createTest('send errors for logs')
     .withLogs({ trackingConsent: 'granted' })
     .run(async ({ intakeRegistry, page, flushEvents }) => {

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -10,8 +10,8 @@ import karmaUnexpectedErrorLogReporterPlugin from './karmaUnexpectedErrorLogRepo
 const webpackConfig = webpackBase({
   mode: 'development',
   types: ['jasmine', 'chrome'],
-  // do not replace some build env variables in unit test in order to test different build behaviors
-  keepBuildEnvVariables: ['SDK_VERSION'],
+  version: 'test',
+  includeWorkerString: true,
 })
 
 const reporters = ['spec', 'jasmine-seed', 'karma-skipped-failed', 'karma-duplicate-test-name']

--- a/webpack.base.ts
+++ b/webpack.base.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import webpack from 'webpack'
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin'
 import TerserPlugin from 'terser-webpack-plugin'
-import { buildEnvKeys, getBuildEnvValue } from './scripts/lib/buildEnv.ts'
+import { getBuildEnvDefines } from './scripts/lib/buildEnv.ts'
 
 const tsconfigPath = path.join(import.meta.dirname, 'tsconfig.webpack.json')
 
@@ -12,11 +12,13 @@ export default ({
   filename,
   plugins,
   types,
-  keepBuildEnvVariables,
+  version,
+  includeWorkerString = false,
 }: Pick<webpack.Configuration, 'entry' | 'mode' | 'plugins'> & {
   filename?: string
   types?: string[]
-  keepBuildEnvVariables?: string[]
+  version?: string
+  includeWorkerString?: boolean
 }): webpack.Configuration => ({
   entry,
   mode,
@@ -90,20 +92,13 @@ export default ({
             append: false,
           }
     ),
-    createDefinePlugin({ keepBuildEnvVariables }),
+    new webpack.DefinePlugin(
+      getBuildEnvDefines({
+        setup: 'cdn',
+        version,
+        workerString: includeWorkerString,
+      })
+    ),
     ...(plugins || []),
   ],
 })
-
-export function createDefinePlugin({ keepBuildEnvVariables }: { keepBuildEnvVariables?: string[] } = {}) {
-  return new webpack.DefinePlugin(
-    Object.fromEntries(
-      buildEnvKeys
-        .filter((key) => !keepBuildEnvVariables?.includes(key))
-        .map((key) => [
-          `__BUILD_ENV__${key}__`,
-          webpack.DefinePlugin.runtimeValue(() => JSON.stringify(getBuildEnvValue(key))),
-        ])
-    )
-  )
-}


### PR DESCRIPTION
## Motivation

Telemetry emitted by CDN bundles currently reports `sdk_setup: "npm"`. This makes it difficult to accurately understand how customers install and use the Browser SDK.

CDN bundles should report `sdk_setup: "cdn"`, while npm builds should continue reporting `sdk_setup: "npm"`.

## Changes

- Report the correct SDK setup for CDN and npm builds.
- Simplify the build environment configuration and make build-specific values explicit.

## Test instructions

1. Run `yarn build:bundle`.
2. Run `rg -o 'sdk_setup.{6}' packages/*/bundle/*.js`.
3. Confirm that CDN bundles report `sdk_setup:"cdn"`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
