### PR TITLE
🐛 Fix Shopify Custom Pixel actions being marked as background events, flatten ui_extension_errored context

### DIFF
--- a/packages/browser-rum-shopify/src/boot/patchSandboxedIframeApis.ts
+++ b/packages/browser-rum-shopify/src/boot/patchSandboxedIframeApis.ts
@@ -11,8 +11,10 @@ import { globalObject } from '@datadog/browser-core'
  * denied without Permissions Policy delegation), but the SDK only catches an async rejection.
  * - `getPristineWindow()` creates a nested iframe to read an unpatched `URL` constructor; that
  * nested iframe's `contentWindow` is cross-origin here, and reading a property off it throws.
+ * - `document.hasFocus()` always returns `false`: the pixel iframe has no focusable UI, so it can
+ * never hold browser focus regardless of whether the customer is actively looking at the page.
  * Shimming these away makes the SDK fall back to code paths that do work in this context
- * (`document.cookie`, same-document promise chaining, `globalObject.URL`).
+ * (`document.cookie`, same-document promise chaining, `globalObject.URL`, always-focused state).
  */
 export function patchSandboxedIframeApis() {
   disableProperty(globalObject, 'cookieStore')
@@ -23,6 +25,12 @@ export function patchSandboxedIframeApis() {
       return null
     },
     configurable: true,
+  })
+
+  Object.defineProperty(document, 'hasFocus', {
+    value: () => true,
+    configurable: true,
+    writable: true,
   })
 }
 

--- a/packages/browser-rum-shopify/src/domain/shopifyBindings.spec.ts
+++ b/packages/browser-rum-shopify/src/domain/shopifyBindings.spec.ts
@@ -122,7 +122,7 @@ describe('initShopifyBindings', () => {
     expect(stopAction).toHaveBeenCalledWith('element-without-id', { type: 'click' })
   })
 
-  it('maps "ui_extension_errored" to addError with the extension context', () => {
+  it('maps "ui_extension_errored" to addError with the flattened extension context', () => {
     const { rumPublicApi, addError } = createFakeRumPublicApi()
     const { analytics, emit } = createFakeAnalytics()
 
@@ -138,18 +138,20 @@ describe('initShopifyBindings', () => {
           extensionName: 'my-extension',
           extensionTarget: 'purchase.checkout.block.render',
           type: 'RUNTIME',
+          appId: 'gid://shopify/App/1',
           appName: 'my-app',
+          appVersion: '1.2.3',
         },
       },
     })
 
     expect(addError).toHaveBeenCalledWith(jasmine.objectContaining({ message: 'Boom', stack: 'stack trace' }), {
-      extension: {
-        name: 'my-extension',
-        target: 'purchase.checkout.block.render',
-        type: 'RUNTIME',
-        appName: 'my-app',
-      },
+      extensionName: 'my-extension',
+      extensionTarget: 'purchase.checkout.block.render',
+      extensionErrorType: 'RUNTIME',
+      appId: 'gid://shopify/App/1',
+      appName: 'my-app',
+      appVersion: '1.2.3',
     })
   })
 })

--- a/packages/browser-rum-shopify/src/domain/shopifyBindings.ts
+++ b/packages/browser-rum-shopify/src/domain/shopifyBindings.ts
@@ -11,7 +11,9 @@ export interface ErrorData {
   extensionName?: string
   extensionTarget?: string
   type?: string
+  appId?: string
   appName?: string
+  appVersion?: string
 }
 
 // Matches /checkouts/*, /checkout, including locale-prefixed paths.
@@ -54,12 +56,12 @@ export function initShopifyBindings(rumPublicApi: RumPublicApi, analytics: Shopi
     const err = new Error(error?.message)
     err.stack = error?.trace
     rumPublicApi.addError(err, {
-      extension: {
-        name: error?.extensionName,
-        target: error?.extensionTarget,
-        type: error?.type,
-        appName: error?.appName,
-      },
+      extensionName: error?.extensionName,
+      extensionTarget: error?.extensionTarget,
+      extensionErrorType: error?.type,
+      appId: error?.appId,
+      appName: error?.appName,
+      appVersion: error?.appVersion,
     })
   })
 }


### PR DESCRIPTION
## Motivation

[RUM-18056](https://datadoghq.atlassian.net/browse/RUM-18056)

Two related fixes to the Shopify Custom Pixel integration:

1. Clicks tracked via `startAction`/`stopAction` in the Custom Pixel sandbox were always being reported with `view.in_foreground: false`. The pixel runs in a sandboxed iframe with no focusable UI, so `document.hasFocus()` always returns `false` there, which `pageStateHistory.ts` interprets as the page being backgrounded — even when the customer is actively on the checkout page.
2. Addresses [review feedback on #4878](https://github.com/DataDog/browser-sdk/pull/4878#discussion_r3622767715): the `ui_extension_errored` error context nested an `extension: { name, target, type, appName }` object whose `type` field read as the same concept as the SDK's own error-name-derived `type`, but is actually an unrelated Shopify `UiExtensionErrorType` enum (e.g. `EXTENSION_USAGE_ERROR`).

## Changes

- `patchSandboxedIframeApis.ts`: shims `document.hasFocus()` to always return `true` inside the Custom Pixel sandbox, alongside the existing `cookieStore`/`navigator.locks`/`contentWindow` shims for that same sandboxed context.
- `shopifyBindings.ts`: flattens the `ui_extension_errored` context and renames `type` to `extensionErrorType` to disambiguate it from the SDK's own error type. Also forwards `appId` and `appVersion`, which Shopify includes on the error payload but weren't previously captured.
- Updated `shopifyBindings.spec.ts` for the new flattened shape.

## Test instructions

- `yarn test:unit --spec packages/browser-rum-shopify/src/domain/shopifyBindings.spec.ts` passes

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

[RUM-18056]: https://datadoghq.atlassian.net/browse/RUM-18056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ