### PR TITLE
⚗️ Add canvas recording init configuration

### DIFF
--- a/packages/browser-core/src/tools/experimentalFeatures.ts
+++ b/packages/browser-core/src/tools/experimentalFeatures.ts
@@ -14,7 +14,7 @@ import { objectHasValue } from './utils/objectUtils'
 
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
-  RECORD_CANVAS = 'record_canvas',
+  SESSION_REPLAY_RECORD_CANVAS = 'session_replay_record_canvas',
   TRACK_INTAKE_REQUESTS = 'track_intake_requests',
   TRACK_WEBSOCKETS = 'track_websockets',
 }

--- a/packages/browser-core/src/tools/experimentalFeatures.ts
+++ b/packages/browser-core/src/tools/experimentalFeatures.ts
@@ -14,6 +14,7 @@ import { objectHasValue } from './utils/objectUtils'
 
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
+  RECORD_CANVAS = 'record_canvas',
   TRACK_INTAKE_REQUESTS = 'track_intake_requests',
   TRACK_WEBSOCKETS = 'track_websockets',
 }

--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -332,18 +332,16 @@ describe('validateAndBuildRumConfiguration', () => {
     it('is disabled by default', () => {
       const configuration = validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!
 
-      expect(configuration.enableSessionReplayCanvasRecording).toBeFalse()
-      expect(configuration.sessionReplayMaxCanvasFps).toBe(0)
+      expect(configuration.enableSessionReplayCanvasRecording).toBeUndefined()
     })
 
     it('stays disabled when requested without the experimental feature', () => {
       const configuration = validateAndBuildRumConfiguration({
         ...DEFAULT_INIT_CONFIGURATION,
-        enableSessionReplayCanvasRecording: true,
+        enableSessionReplayCanvasRecording: {},
       })!
 
-      expect(configuration.enableSessionReplayCanvasRecording).toBeFalse()
-      expect(configuration.sessionReplayMaxCanvasFps).toBe(0)
+      expect(configuration.enableSessionReplayCanvasRecording).toBeUndefined()
     })
 
     describe('when the experimental feature is enabled', () => {
@@ -354,21 +352,29 @@ describe('validateAndBuildRumConfiguration', () => {
       it('uses one frame per second by default when enabled', () => {
         const configuration = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
-          enableSessionReplayCanvasRecording: true,
+          enableSessionReplayCanvasRecording: {},
         })!
 
-        expect(configuration.enableSessionReplayCanvasRecording).toBeTrue()
-        expect(configuration.sessionReplayMaxCanvasFps).toBe(1)
+        expect(configuration.enableSessionReplayCanvasRecording).toEqual({ maxFramesPerSecond: 1 })
       })
 
       it('uses the configured frame rate', () => {
         const configuration = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
-          enableSessionReplayCanvasRecording: true,
-          sessionReplayMaxCanvasFps: 2.5,
+          enableSessionReplayCanvasRecording: { maxFramesPerSecond: 2.5 },
         })!
 
-        expect(configuration.sessionReplayMaxCanvasFps).toBe(2.5)
+        expect(configuration.enableSessionReplayCanvasRecording).toEqual({ maxFramesPerSecond: 2.5 })
+      })
+
+      it('rejects invalid canvas recording options', () => {
+        expect(
+          validateAndBuildRumConfiguration({
+            ...DEFAULT_INIT_CONFIGURATION,
+            enableSessionReplayCanvasRecording: true as any,
+          })
+        ).toBeUndefined()
+        expect(displayErrorSpy).toHaveBeenCalledOnceWith('"enableSessionReplayCanvasRecording" is not a valid object')
       })
     })
   })
@@ -923,8 +929,7 @@ describe('serializeRumConfiguration', () => {
       trackResourceHeaders: true,
       betaEnableViewUpdates: true,
       betaTrackWebSockets: false,
-      enableSessionReplayCanvasRecording: true,
-      sessionReplayMaxCanvasFps: 2.5,
+      enableSessionReplayCanvasRecording: { maxFramesPerSecond: 2.5 },
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -940,12 +945,7 @@ describe('serializeRumConfiguration', () => {
           ? 'track_long_task' // We forgot the s, keeping this for backward compatibility
           : // The following options are not reported as telemetry. Please avoid adding more of them.
             // `remoteConfiguration` is covered by the legacy `remote_configuration_id` field.
-            Key extends
-                | 'applicationId'
-                | 'subdomain'
-                | 'remoteConfiguration'
-                | 'enableSessionReplayCanvasRecording'
-                | 'sessionReplayMaxCanvasFps'
+            Key extends 'applicationId' | 'subdomain' | 'remoteConfiguration' | 'enableSessionReplayCanvasRecording'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -348,7 +348,7 @@ describe('validateAndBuildRumConfiguration', () => {
 
     describe('when the experimental feature is enabled', () => {
       beforeEach(() => {
-        addExperimentalFeatures([ExperimentalFeature.RECORD_CANVAS])
+        addExperimentalFeatures([ExperimentalFeature.SESSION_REPLAY_RECORD_CANVAS])
       })
 
       it('uses one frame per second by default when enabled', () => {

--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -333,7 +333,7 @@ describe('validateAndBuildRumConfiguration', () => {
       const configuration = validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!
 
       expect(configuration.enableSessionReplayCanvasRecording).toBeFalse()
-      expect(configuration.sessionReplayMaxCanvasFPS).toBe(0)
+      expect(configuration.sessionReplayMaxCanvasFps).toBe(0)
     })
 
     it('stays disabled when requested without the experimental feature', () => {
@@ -343,7 +343,7 @@ describe('validateAndBuildRumConfiguration', () => {
       })!
 
       expect(configuration.enableSessionReplayCanvasRecording).toBeFalse()
-      expect(configuration.sessionReplayMaxCanvasFPS).toBe(0)
+      expect(configuration.sessionReplayMaxCanvasFps).toBe(0)
     })
 
     describe('when the experimental feature is enabled', () => {
@@ -358,17 +358,17 @@ describe('validateAndBuildRumConfiguration', () => {
         })!
 
         expect(configuration.enableSessionReplayCanvasRecording).toBeTrue()
-        expect(configuration.sessionReplayMaxCanvasFPS).toBe(1)
+        expect(configuration.sessionReplayMaxCanvasFps).toBe(1)
       })
 
       it('uses the configured frame rate', () => {
         const configuration = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
           enableSessionReplayCanvasRecording: true,
-          sessionReplayMaxCanvasFPS: 2.5,
+          sessionReplayMaxCanvasFps: 2.5,
         })!
 
-        expect(configuration.sessionReplayMaxCanvasFPS).toBe(2.5)
+        expect(configuration.sessionReplayMaxCanvasFps).toBe(2.5)
       })
     })
   })
@@ -924,7 +924,7 @@ describe('serializeRumConfiguration', () => {
       betaEnableViewUpdates: true,
       betaTrackWebSockets: false,
       enableSessionReplayCanvasRecording: true,
-      sessionReplayMaxCanvasFPS: 2.5,
+      sessionReplayMaxCanvasFps: 2.5,
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -945,7 +945,7 @@ describe('serializeRumConfiguration', () => {
                 | 'subdomain'
                 | 'remoteConfiguration'
                 | 'enableSessionReplayCanvasRecording'
-                | 'sessionReplayMaxCanvasFPS'
+                | 'sessionReplayMaxCanvasFps'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -1,5 +1,11 @@
 import type { InitConfiguration } from '@datadog/browser-core'
-import { DefaultPrivacyLevel, display, TraceContextInjection } from '@datadog/browser-core'
+import {
+  addExperimentalFeatures,
+  DefaultPrivacyLevel,
+  display,
+  ExperimentalFeature,
+  TraceContextInjection,
+} from '@datadog/browser-core'
 import type {
   ExtractTelemetryConfiguration,
   CamelToSnakeCase,
@@ -319,6 +325,51 @@ describe('validateAndBuildRumConfiguration', () => {
           startSessionReplayRecordingManually: 'foo' as any,
         })!.startSessionReplayRecordingManually
       ).toBeTrue()
+    })
+  })
+
+  describe('canvas recording', () => {
+    it('is disabled by default', () => {
+      const configuration = validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!
+
+      expect(configuration.recordCanvas).toBeFalse()
+      expect(configuration.canvasMaxFramesPerSecond).toBe(0)
+    })
+
+    it('stays disabled when requested without the experimental feature', () => {
+      const configuration = validateAndBuildRumConfiguration({
+        ...DEFAULT_INIT_CONFIGURATION,
+        recordCanvas: true,
+      })!
+
+      expect(configuration.recordCanvas).toBeFalse()
+      expect(configuration.canvasMaxFramesPerSecond).toBe(0)
+    })
+
+    describe('when the experimental feature is enabled', () => {
+      beforeEach(() => {
+        addExperimentalFeatures([ExperimentalFeature.RECORD_CANVAS])
+      })
+
+      it('uses one frame per second by default when enabled', () => {
+        const configuration = validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          recordCanvas: true,
+        })!
+
+        expect(configuration.recordCanvas).toBeTrue()
+        expect(configuration.canvasMaxFramesPerSecond).toBe(1)
+      })
+
+      it('uses the configured frame rate', () => {
+        const configuration = validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          recordCanvas: true,
+          canvasMaxFramesPerSecond: 2.5,
+        })!
+
+        expect(configuration.canvasMaxFramesPerSecond).toBe(2.5)
+      })
     })
   })
 
@@ -872,6 +923,8 @@ describe('serializeRumConfiguration', () => {
       trackResourceHeaders: true,
       betaEnableViewUpdates: true,
       betaTrackWebSockets: false,
+      recordCanvas: true,
+      canvasMaxFramesPerSecond: 2.5,
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -887,7 +940,8 @@ describe('serializeRumConfiguration', () => {
           ? 'track_long_task' // We forgot the s, keeping this for backward compatibility
           : // The following options are not reported as telemetry. Please avoid adding more of them.
             // `remoteConfiguration` is covered by the legacy `remote_configuration_id` field.
-            Key extends 'applicationId' | 'subdomain' | 'remoteConfiguration'
+            Key extends
+                'applicationId' | 'subdomain' | 'remoteConfiguration' | 'recordCanvas' | 'canvasMaxFramesPerSecond'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -332,18 +332,18 @@ describe('validateAndBuildRumConfiguration', () => {
     it('is disabled by default', () => {
       const configuration = validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!
 
-      expect(configuration.recordCanvas).toBeFalse()
-      expect(configuration.canvasMaxFramesPerSecond).toBe(0)
+      expect(configuration.enableSessionReplayCanvasRecording).toBeFalse()
+      expect(configuration.sessionReplayMaxCanvasFPS).toBe(0)
     })
 
     it('stays disabled when requested without the experimental feature', () => {
       const configuration = validateAndBuildRumConfiguration({
         ...DEFAULT_INIT_CONFIGURATION,
-        recordCanvas: true,
+        enableSessionReplayCanvasRecording: true,
       })!
 
-      expect(configuration.recordCanvas).toBeFalse()
-      expect(configuration.canvasMaxFramesPerSecond).toBe(0)
+      expect(configuration.enableSessionReplayCanvasRecording).toBeFalse()
+      expect(configuration.sessionReplayMaxCanvasFPS).toBe(0)
     })
 
     describe('when the experimental feature is enabled', () => {
@@ -354,21 +354,21 @@ describe('validateAndBuildRumConfiguration', () => {
       it('uses one frame per second by default when enabled', () => {
         const configuration = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
-          recordCanvas: true,
+          enableSessionReplayCanvasRecording: true,
         })!
 
-        expect(configuration.recordCanvas).toBeTrue()
-        expect(configuration.canvasMaxFramesPerSecond).toBe(1)
+        expect(configuration.enableSessionReplayCanvasRecording).toBeTrue()
+        expect(configuration.sessionReplayMaxCanvasFPS).toBe(1)
       })
 
       it('uses the configured frame rate', () => {
         const configuration = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
-          recordCanvas: true,
-          canvasMaxFramesPerSecond: 2.5,
+          enableSessionReplayCanvasRecording: true,
+          sessionReplayMaxCanvasFPS: 2.5,
         })!
 
-        expect(configuration.canvasMaxFramesPerSecond).toBe(2.5)
+        expect(configuration.sessionReplayMaxCanvasFPS).toBe(2.5)
       })
     })
   })
@@ -923,8 +923,8 @@ describe('serializeRumConfiguration', () => {
       trackResourceHeaders: true,
       betaEnableViewUpdates: true,
       betaTrackWebSockets: false,
-      recordCanvas: true,
-      canvasMaxFramesPerSecond: 2.5,
+      enableSessionReplayCanvasRecording: true,
+      sessionReplayMaxCanvasFPS: 2.5,
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -941,7 +941,11 @@ describe('serializeRumConfiguration', () => {
           : // The following options are not reported as telemetry. Please avoid adding more of them.
             // `remoteConfiguration` is covered by the legacy `remote_configuration_id` field.
             Key extends
-                'applicationId' | 'subdomain' | 'remoteConfiguration' | 'recordCanvas' | 'canvasMaxFramesPerSecond'
+                | 'applicationId'
+                | 'subdomain'
+                | 'remoteConfiguration'
+                | 'enableSessionReplayCanvasRecording'
+                | 'sessionReplayMaxCanvasFPS'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -332,16 +332,16 @@ describe('validateAndBuildRumConfiguration', () => {
     it('is disabled by default', () => {
       const configuration = validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!
 
-      expect(configuration.enableSessionReplayCanvasRecording).toBeUndefined()
+      expect(configuration.sessionReplayCanvasRecording).toBeUndefined()
     })
 
     it('stays disabled when requested without the experimental feature', () => {
       const configuration = validateAndBuildRumConfiguration({
         ...DEFAULT_INIT_CONFIGURATION,
-        enableSessionReplayCanvasRecording: {},
+        sessionReplayCanvasRecording: { enable: true },
       })!
 
-      expect(configuration.enableSessionReplayCanvasRecording).toBeUndefined()
+      expect(configuration.sessionReplayCanvasRecording).toBeUndefined()
     })
 
     describe('when the experimental feature is enabled', () => {
@@ -352,29 +352,51 @@ describe('validateAndBuildRumConfiguration', () => {
       it('uses one frame per second by default when enabled', () => {
         const configuration = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
-          enableSessionReplayCanvasRecording: {},
+          sessionReplayCanvasRecording: { enable: true },
         })!
 
-        expect(configuration.enableSessionReplayCanvasRecording).toEqual({ maxFramesPerSecond: 1 })
+        expect(configuration.sessionReplayCanvasRecording).toEqual({ enable: true, maxFramesPerSecond: 1 })
       })
 
       it('uses the configured frame rate', () => {
         const configuration = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
-          enableSessionReplayCanvasRecording: { maxFramesPerSecond: 2.5 },
+          sessionReplayCanvasRecording: { enable: true, maxFramesPerSecond: 2.5 },
         })!
 
-        expect(configuration.enableSessionReplayCanvasRecording).toEqual({ maxFramesPerSecond: 2.5 })
+        expect(configuration.sessionReplayCanvasRecording).toEqual({ enable: true, maxFramesPerSecond: 2.5 })
+      })
+
+      it('preserves the configured frame rate when disabled', () => {
+        const configuration = validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          sessionReplayCanvasRecording: { enable: false, maxFramesPerSecond: 2.5 },
+        })!
+
+        expect(configuration.sessionReplayCanvasRecording).toEqual({ enable: false, maxFramesPerSecond: 2.5 })
       })
 
       it('rejects invalid canvas recording options', () => {
         expect(
           validateAndBuildRumConfiguration({
             ...DEFAULT_INIT_CONFIGURATION,
-            enableSessionReplayCanvasRecording: true as any,
+            sessionReplayCanvasRecording: true as any,
           })
         ).toBeUndefined()
-        expect(displayErrorSpy).toHaveBeenCalledOnceWith('"enableSessionReplayCanvasRecording" is not a valid object')
+        expect(displayErrorSpy).toHaveBeenCalledOnceWith('"sessionReplayCanvasRecording" is not a valid object')
+      })
+
+      it('requires the enable option', () => {
+        expect(
+          validateAndBuildRumConfiguration({
+            ...DEFAULT_INIT_CONFIGURATION,
+            sessionReplayCanvasRecording: {} as any,
+          })
+        ).toBeUndefined()
+        expect(displayErrorSpy.calls.allArgs()).toEqual([
+          ['"enable" is required'],
+          ['"sessionReplayCanvasRecording" is not a valid object'],
+        ])
       })
     })
   })
@@ -929,7 +951,7 @@ describe('serializeRumConfiguration', () => {
       trackResourceHeaders: true,
       betaEnableViewUpdates: true,
       betaTrackWebSockets: false,
-      enableSessionReplayCanvasRecording: { maxFramesPerSecond: 2.5 },
+      sessionReplayCanvasRecording: { enable: true, maxFramesPerSecond: 2.5 },
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -945,7 +967,7 @@ describe('serializeRumConfiguration', () => {
           ? 'track_long_task' // We forgot the s, keeping this for backward compatibility
           : // The following options are not reported as telemetry. Please avoid adding more of them.
             // `remoteConfiguration` is covered by the legacy `remote_configuration_id` field.
-            Key extends 'applicationId' | 'subdomain' | 'remoteConfiguration' | 'enableSessionReplayCanvasRecording'
+            Key extends 'applicationId' | 'subdomain' | 'remoteConfiguration' | 'sessionReplayCanvasRecording'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -230,7 +230,7 @@ export interface RumInitConfiguration extends InitConfiguration {
    * @defaultValue 1
    * @hidden
    */
-  sessionReplayMaxCanvasFPS?: number | undefined
+  sessionReplayMaxCanvasFps?: number | undefined
 
   /**
    * Enables privacy control for action names.
@@ -416,7 +416,7 @@ export const RUM_SCHEMA = {
   propagateTraceBaggage: { type: 'boolean', default: true },
   startSessionReplayRecordingManually: { type: 'boolean', default: false, strict: false },
   enableSessionReplayCanvasRecording: { type: 'boolean', default: false },
-  sessionReplayMaxCanvasFPS: { type: 'number', min: 0, max: 5, default: 1 },
+  sessionReplayMaxCanvasFps: { type: 'number', min: 0, max: 5, default: 1 },
 
   // Enums
   defaultPrivacyLevel: {
@@ -516,7 +516,7 @@ export function validateAndBuildRumConfiguration(
   return {
     ...config,
     enableSessionReplayCanvasRecording,
-    sessionReplayMaxCanvasFPS: enableSessionReplayCanvasRecording ? config.sessionReplayMaxCanvasFPS : 0,
+    sessionReplayMaxCanvasFps: enableSessionReplayCanvasRecording ? config.sessionReplayMaxCanvasFps : 0,
     allowedTracingUrls,
     beforeSend: config.beforeSend
       ? (catchUserErrors(config.beforeSend, 'beforeSend threw an error:') as typeof config.beforeSend)

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -220,17 +220,17 @@ export interface RumInitConfiguration extends InitConfiguration {
    * @defaultValue false
    * @hidden
    */
-  recordCanvas?: boolean | undefined
+  enableSessionReplayCanvasRecording?: boolean | undefined
 
   /**
    * The maximum number of canvas frames recorded per second. Setting this option to `0` disables canvas frame recording.
-   * This option has no effect unless {@link RumInitConfiguration.recordCanvas | recordCanvas} is enabled.
+   * This option has no effect unless {@link RumInitConfiguration.enableSessionReplayCanvasRecording | enableSessionReplayCanvasRecording} is enabled.
    *
    * @category Session Replay
    * @defaultValue 1
    * @hidden
    */
-  canvasMaxFramesPerSecond?: number | undefined
+  sessionReplayMaxCanvasFPS?: number | undefined
 
   /**
    * Enables privacy control for action names.
@@ -415,8 +415,8 @@ export const RUM_SCHEMA = {
   enablePrivacyForActionName: { type: 'boolean', default: true },
   propagateTraceBaggage: { type: 'boolean', default: true },
   startSessionReplayRecordingManually: { type: 'boolean', default: false, strict: false },
-  recordCanvas: { type: 'boolean', default: false },
-  canvasMaxFramesPerSecond: { type: 'number', min: 0, max: 5, default: 1 },
+  enableSessionReplayCanvasRecording: { type: 'boolean', default: false },
+  sessionReplayMaxCanvasFPS: { type: 'number', min: 0, max: 5, default: 1 },
 
   // Enums
   defaultPrivacyLevel: {
@@ -509,12 +509,13 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
-  const recordCanvas = config.recordCanvas && isExperimentalFeatureEnabled(ExperimentalFeature.RECORD_CANVAS)
+  const enableSessionReplayCanvasRecording =
+    config.enableSessionReplayCanvasRecording && isExperimentalFeatureEnabled(ExperimentalFeature.RECORD_CANVAS)
 
   return {
     ...config,
-    recordCanvas,
-    canvasMaxFramesPerSecond: recordCanvas ? config.canvasMaxFramesPerSecond : 0,
+    enableSessionReplayCanvasRecording,
+    sessionReplayMaxCanvasFPS: enableSessionReplayCanvasRecording ? config.sessionReplayMaxCanvasFPS : 0,
     allowedTracingUrls,
     beforeSend: config.beforeSend
       ? (catchUserErrors(config.beforeSend, 'beforeSend threw an error:') as typeof config.beforeSend)

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -510,7 +510,8 @@ export function validateAndBuildRumConfiguration(
   }
 
   const enableSessionReplayCanvasRecording =
-    config.enableSessionReplayCanvasRecording && isExperimentalFeatureEnabled(ExperimentalFeature.RECORD_CANVAS)
+    config.enableSessionReplayCanvasRecording &&
+    isExperimentalFeatureEnabled(ExperimentalFeature.SESSION_REPLAY_RECORD_CANVAS)
 
   return {
     ...config,

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -5,6 +5,8 @@ import {
   DefaultPrivacyLevel,
   TraceContextInjection,
   display,
+  ExperimentalFeature,
+  isExperimentalFeatureEnabled,
   isNumber,
   isNonEmptyArray,
   BROWSER_CORE_SCHEMA,
@@ -212,6 +214,25 @@ export interface RumInitConfiguration extends InitConfiguration {
   startSessionReplayRecordingManually?: boolean | undefined
 
   /**
+   * Enables recording canvas elements in Session Replay.
+   *
+   * @category Session Replay
+   * @defaultValue false
+   * @hidden
+   */
+  recordCanvas?: boolean | undefined
+
+  /**
+   * The maximum number of canvas frames recorded per second. Setting this option to `0` disables canvas frame recording.
+   * This option has no effect unless {@link RumInitConfiguration.recordCanvas | recordCanvas} is enabled.
+   *
+   * @category Session Replay
+   * @defaultValue 1
+   * @hidden
+   */
+  canvasMaxFramesPerSecond?: number | undefined
+
+  /**
    * Enables privacy control for action names.
    *
    * @category Privacy
@@ -394,6 +415,8 @@ export const RUM_SCHEMA = {
   enablePrivacyForActionName: { type: 'boolean', default: true },
   propagateTraceBaggage: { type: 'boolean', default: true },
   startSessionReplayRecordingManually: { type: 'boolean', default: false, strict: false },
+  recordCanvas: { type: 'boolean', default: false },
+  canvasMaxFramesPerSecond: { type: 'number', min: 0, max: 5, default: 1 },
 
   // Enums
   defaultPrivacyLevel: {
@@ -486,8 +509,12 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
+  const recordCanvas = config.recordCanvas && isExperimentalFeatureEnabled(ExperimentalFeature.RECORD_CANVAS)
+
   return {
     ...config,
+    recordCanvas,
+    canvasMaxFramesPerSecond: recordCanvas ? config.canvasMaxFramesPerSecond : 0,
     allowedTracingUrls,
     beforeSend: config.beforeSend
       ? (catchUserErrors(config.beforeSend, 'beforeSend threw an error:') as typeof config.beforeSend)

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -219,10 +219,15 @@ export interface RumInitConfiguration extends InitConfiguration {
    * @category Session Replay
    * @hidden
    */
-  enableSessionReplayCanvasRecording?:
+  sessionReplayCanvasRecording?:
     | {
         /**
-         * The maximum number of canvas frames recorded per second. Setting this option to `0` disables canvas frame recording.
+         * Enables recording canvas elements in Session Replay.
+         */
+        enable: boolean
+
+        /**
+         * The maximum number of canvas frames recorded per second, between 0 and 5. Setting this option to `0` disables canvas frame recording.
          *
          * @defaultValue 1
          */
@@ -413,9 +418,10 @@ export const RUM_SCHEMA = {
   enablePrivacyForActionName: { type: 'boolean', default: true },
   propagateTraceBaggage: { type: 'boolean', default: true },
   startSessionReplayRecordingManually: { type: 'boolean', default: false, strict: false },
-  enableSessionReplayCanvasRecording: {
+  sessionReplayCanvasRecording: {
     type: 'schema',
     schema: {
+      enable: { type: 'boolean', required: true },
       maxFramesPerSecond: { type: 'number', min: 0, max: 5, default: 1 },
     },
   },
@@ -511,15 +517,13 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
-  const enableSessionReplayCanvasRecording = isExperimentalFeatureEnabled(
-    ExperimentalFeature.SESSION_REPLAY_RECORD_CANVAS
-  )
-    ? config.enableSessionReplayCanvasRecording
+  const sessionReplayCanvasRecording = isExperimentalFeatureEnabled(ExperimentalFeature.SESSION_REPLAY_RECORD_CANVAS)
+    ? config.sessionReplayCanvasRecording
     : undefined
 
   return {
     ...config,
-    enableSessionReplayCanvasRecording,
+    sessionReplayCanvasRecording,
     allowedTracingUrls,
     beforeSend: config.beforeSend
       ? (catchUserErrors(config.beforeSend, 'beforeSend threw an error:') as typeof config.beforeSend)

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -214,23 +214,21 @@ export interface RumInitConfiguration extends InitConfiguration {
   startSessionReplayRecordingManually?: boolean | undefined
 
   /**
-   * Enables recording canvas elements in Session Replay.
+   * Configures recording canvas elements in Session Replay. Canvas recording is disabled when this option is omitted.
    *
    * @category Session Replay
-   * @defaultValue false
    * @hidden
    */
-  enableSessionReplayCanvasRecording?: boolean | undefined
-
-  /**
-   * The maximum number of canvas frames recorded per second. Setting this option to `0` disables canvas frame recording.
-   * This option has no effect unless {@link RumInitConfiguration.enableSessionReplayCanvasRecording | enableSessionReplayCanvasRecording} is enabled.
-   *
-   * @category Session Replay
-   * @defaultValue 1
-   * @hidden
-   */
-  sessionReplayMaxCanvasFps?: number | undefined
+  enableSessionReplayCanvasRecording?:
+    | {
+        /**
+         * The maximum number of canvas frames recorded per second. Setting this option to `0` disables canvas frame recording.
+         *
+         * @defaultValue 1
+         */
+        maxFramesPerSecond?: number | undefined
+      }
+    | undefined
 
   /**
    * Enables privacy control for action names.
@@ -415,8 +413,12 @@ export const RUM_SCHEMA = {
   enablePrivacyForActionName: { type: 'boolean', default: true },
   propagateTraceBaggage: { type: 'boolean', default: true },
   startSessionReplayRecordingManually: { type: 'boolean', default: false, strict: false },
-  enableSessionReplayCanvasRecording: { type: 'boolean', default: false },
-  sessionReplayMaxCanvasFps: { type: 'number', min: 0, max: 5, default: 1 },
+  enableSessionReplayCanvasRecording: {
+    type: 'schema',
+    schema: {
+      maxFramesPerSecond: { type: 'number', min: 0, max: 5, default: 1 },
+    },
+  },
 
   // Enums
   defaultPrivacyLevel: {
@@ -509,14 +511,15 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
-  const enableSessionReplayCanvasRecording =
-    config.enableSessionReplayCanvasRecording &&
-    isExperimentalFeatureEnabled(ExperimentalFeature.SESSION_REPLAY_RECORD_CANVAS)
+  const enableSessionReplayCanvasRecording = isExperimentalFeatureEnabled(
+    ExperimentalFeature.SESSION_REPLAY_RECORD_CANVAS
+  )
+    ? config.enableSessionReplayCanvasRecording
+    : undefined
 
   return {
     ...config,
     enableSessionReplayCanvasRecording,
-    sessionReplayMaxCanvasFps: enableSessionReplayCanvasRecording ? config.sessionReplayMaxCanvasFps : 0,
     allowedTracingUrls,
     beforeSend: config.beforeSend
       ? (catchUserErrors(config.beforeSend, 'beforeSend threw an error:') as typeof config.beforeSend)

--- a/packages/js-core/api/configuration.api.md
+++ b/packages/js-core/api/configuration.api.md
@@ -26,7 +26,7 @@ export type EnumField = ({
 } & Optionality & Multiple & Strict);
 
 // @public
-export type FieldDef = StringField | PercentageField | BooleanField | SiteField | MatchOptionField | EnumField | UnionField | SchemaField | FunctionField;
+export type FieldDef = StringField | NumberField | PercentageField | BooleanField | SiteField | MatchOptionField | EnumField | UnionField | SchemaField | FunctionField;
 
 // @public
 export type FunctionField = {
@@ -53,6 +53,13 @@ export type MatchOptionField = {
 export interface Multiple {
     multiple?: true;
 }
+
+// @public
+export type NumberField = {
+    type: 'number';
+    min?: number;
+    max?: number;
+} & Optionality & Multiple & Strict;
 
 // @public
 export type Optionality = {

--- a/packages/js-core/src/entries/configuration.spec.ts
+++ b/packages/js-core/src/entries/configuration.spec.ts
@@ -69,6 +69,44 @@ describe('validateAndBuildConfiguration', () => {
     })
   })
 
+  describe('number fields', () => {
+    it('accepts finite numbers without bounds', () => {
+      const schema = { value: { type: 'number', required: true } } as const
+
+      expect(validateAndBuildConfiguration({ value: -42.5 }, schema, display)).toEqual({ value: -42.5 })
+    })
+
+    it('accepts finite numbers within inclusive bounds', () => {
+      const schema = { value: { type: 'number', min: 0, max: 5, required: true } } as const
+
+      expect(validateAndBuildConfiguration({ value: 0 }, schema, display)).toEqual({ value: 0 })
+      expect(validateAndBuildConfiguration({ value: 2.5 }, schema, display)).toEqual({ value: 2.5 })
+      expect(validateAndBuildConfiguration({ value: 5 }, schema, display)).toEqual({ value: 5 })
+    })
+
+    it('rejects non-finite numbers and values outside the bounds', () => {
+      const schema = { value: { type: 'number', min: 0, max: 5, default: 1 } } as const
+
+      ;[-1, 6, NaN, Infinity, '1'].forEach((value) => {
+        expect(validateAndBuildConfiguration({ value }, schema, display)).toBeUndefined()
+      })
+    })
+
+    it('uses the default when missing', () => {
+      const schema = { value: { type: 'number', default: 1 } } as const
+
+      expect(validateAndBuildConfiguration({}, schema, display)).toEqual({ value: 1 })
+    })
+
+    it('supports one-sided bounds', () => {
+      const minimumSchema = { value: { type: 'number', min: 0, required: true } } as const
+      const maximumSchema = { value: { type: 'number', max: 5, required: true } } as const
+
+      expect(validateAndBuildConfiguration({ value: -1 }, minimumSchema, display)).toBeUndefined()
+      expect(validateAndBuildConfiguration({ value: 6 }, maximumSchema, display)).toBeUndefined()
+    })
+  })
+
   describe('enum fields with allowAll', () => {
     const VALUES = ['a', 'b', 'c'] as const
     const schema = {
@@ -487,6 +525,30 @@ describe('validateAndBuildConfiguration', () => {
       const schema = { rate: { type: 'percentage' as const, default: 100 } }
       validateAndBuildConfiguration({ rate: 200 }, schema, display)
       expect(display.error).toHaveBeenCalledOnceWith('"rate" must be a number between 0 and 100')
+    })
+
+    it('reports the configured bounds for an invalid number', () => {
+      const schema = { value: { type: 'number' as const, min: 0, max: 5, default: 1 } }
+      validateAndBuildConfiguration({ value: 6 }, schema, display)
+      expect(display.error).toHaveBeenCalledOnceWith('"value" must be a number between 0 and 5')
+    })
+
+    it('reports a configured minimum for an invalid number', () => {
+      const schema = { value: { type: 'number' as const, min: 0 } }
+      validateAndBuildConfiguration({ value: -1 }, schema, display)
+      expect(display.error).toHaveBeenCalledOnceWith('"value" must be a number greater than or equal to 0')
+    })
+
+    it('reports a configured maximum for an invalid number', () => {
+      const schema = { value: { type: 'number' as const, max: 5 } }
+      validateAndBuildConfiguration({ value: 6 }, schema, display)
+      expect(display.error).toHaveBeenCalledOnceWith('"value" must be a number less than or equal to 5')
+    })
+
+    it('reports finite-number requirements for an unbounded number', () => {
+      const schema = { value: { type: 'number' as const } }
+      validateAndBuildConfiguration({ value: Infinity }, schema, display)
+      expect(display.error).toHaveBeenCalledOnceWith('"value" must be a finite number')
     })
 
     it('reports the right message for an invalid boolean', () => {

--- a/packages/js-core/src/entries/configuration.ts
+++ b/packages/js-core/src/entries/configuration.ts
@@ -43,6 +43,9 @@ export type StringField = { type: 'string' } & Optionality & Multiple & Strict
 /** A numeric field constrained to the 0–100 range, typically used for sample rates. */
 export type PercentageField = { type: 'percentage' } & Optionality & Multiple & Strict
 
+/** A finite numeric field, optionally constrained by inclusive minimum and maximum values. */
+export type NumberField = { type: 'number'; min?: number; max?: number } & Optionality & Multiple & Strict
+
 /**
  * A boolean field. When `strict: false`, a non-boolean value is coerced with `!!value`
  * instead of being rejected.
@@ -100,6 +103,7 @@ export type FunctionField = {
 /** The union of all field definition types supported by a {@link ConfigurationSchema}. */
 export type FieldDef =
   | StringField
+  | NumberField
   | PercentageField
   | BooleanField
   | SiteField
@@ -125,7 +129,7 @@ export interface ConfigurationSchema {
 
 type InferBase<F extends FieldDef> = F extends { type: 'string' }
   ? string
-  : F extends { type: 'percentage' }
+  : F extends { type: 'number' | 'percentage' }
     ? number
     : F extends { type: 'boolean' }
       ? boolean
@@ -154,7 +158,7 @@ type InferBase<F extends FieldDef> = F extends { type: 'string' }
 // Non-recursive variant of InferBase used inside UnionField to avoid infinite type instantiation.
 type InferVariant<F> = F extends { type: 'string' }
   ? string
-  : F extends { type: 'percentage' }
+  : F extends { type: 'number' | 'percentage' }
     ? number
     : F extends { type: 'boolean' }
       ? boolean
@@ -229,6 +233,17 @@ function buildErrorMessage(key: string, field: FieldDef): string {
   switch (field.type) {
     case 'string':
       return `"${key}" must be a non-empty string`
+    case 'number':
+      if (field.min !== undefined && field.max !== undefined) {
+        return `"${key}" must be a number between ${field.min} and ${field.max}`
+      }
+      if (field.min !== undefined) {
+        return `"${key}" must be a number greater than or equal to ${field.min}`
+      }
+      if (field.max !== undefined) {
+        return `"${key}" must be a number less than or equal to ${field.max}`
+      }
+      return `"${key}" must be a finite number`
     case 'percentage':
       return `"${key}" must be a number between 0 and 100`
     case 'boolean':
@@ -375,6 +390,13 @@ function validateField(field: FieldDef, value: unknown, display: Display): unkno
       return typeof value === 'function' ? value : undefined
     case 'string':
       return typeof value === 'string' && value.length > 0 ? value : undefined
+    case 'number':
+      return typeof value === 'number' &&
+        Number.isFinite(value) &&
+        (field.min === undefined || value >= field.min) &&
+        (field.max === undefined || value <= field.max)
+        ? value
+        : undefined
     case 'percentage':
       return isPercentage(value) ? value : undefined
     case 'boolean':


### PR DESCRIPTION
## Motivation

Prepare the Browser SDK configuration surface for Session Replay canvas recording while keeping the capability behind an experimental feature flag. Grouping canvas recording settings in an object leaves room for future controls such as maximum image size or compression type without adding more top-level initialization parameters. Keeping `enable` separate from the related settings also allows canvas recording to be toggled without losing values such as the configured maximum FPS.

Design references:

- [One Pager: Session Replay Canvas Support](https://datadoghq.atlassian.net/wiki/spaces/PANA/pages/6882561949/One+Pager+Session+Replay+Canvas+Support)
- [Browser SDK Canvas Support](https://datadoghq.atlassian.net/wiki/spaces/PANA/pages/7082737787/Browser+SDK+Canvas+Support)

## Changes

- Add the hidden `sessionReplayCanvasRecording` RUM initialization object with this shape:

  ```ts
  sessionReplayCanvasRecording?: {
    enable: boolean
    maxFramesPerSecond?: number
  }
  ```

- Require `enable` so canvas recording can be explicitly enabled or disabled while preserving related settings.
- Default `maxFramesPerSecond` to 1 FPS and validate it at runtime as a finite number in the inclusive range `[0, 5]`. Setting it to `0` disables canvas frame recording.
- Require both `sessionReplayCanvasRecording.enable: true` and the `session_replay_record_canvas` experimental feature flag for recording to be effective.
- Keep canvas recording disabled when the configuration object is omitted or the experimental feature is unavailable.
- Add a reusable finite `number` field to the js-core configuration schema, with optional inclusive `min` and `max` bounds.
- Update the js-core API report and add focused unit coverage for defaults, custom frame rates, enabled and disabled states, feature gating, missing required fields, and invalid option shapes.

## Test instructions

- `yarn test:unit --spec packages/js-core/src/entries/configuration.spec.ts --spec packages/browser-rum-core/src/domain/configuration/configuration.spec.ts`
- `yarn typecheck`
- `yarn api:check`
- ESLint and Prettier checks on the changed source and test files.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
