### PR TITLE
🐛 [devext] support v7 session cookie and expose anonymous ID / account context

### DIFF
--- a/developer-extension/src/panel/components/tabs/infosTab.tsx
+++ b/developer-extension/src/panel/components/tabs/infosTab.tsx
@@ -105,6 +105,7 @@ export function InfosTab() {
               {infos.cookie.forcedReplay && <Entry name="Is Replay Forced" value={'True'} />}
               <Entry name="Created" value={infos.cookie.created && formatDate(Number(infos.cookie.created))} />
               <Entry name="Expire" value={infos.cookie.expire && formatDate(Number(infos.cookie.expire))} />
+              <Entry name="Anonymous ID" value={infos.cookie.anonymousId} />
               <Button color="violet" variant="light" onClick={endSession} className="dd-privacy-allow">
                 End current session
               </Button>
@@ -145,6 +146,7 @@ export function InfosTab() {
               <Entry name="Internal context" value={infos.rum.internalContext} />
               <Entry name="Global context" value={infos.rum.globalContext} />
               <Entry name="User" value={infos.rum.user} />
+              <Entry name="Account" value={infos.rum.account} />
             </>
           )}
         </Columns.Column>
@@ -176,6 +178,7 @@ export function InfosTab() {
               />
               <Entry name="Global context" value={infos.logs.globalContext} />
               <Entry name="User" value={infos.logs.user} />
+              <Entry name="Account" value={infos.logs.account} />
             </>
           )}
         </Columns.Column>
@@ -325,6 +328,7 @@ function endSession() {
   evalInWindow(
     `
       document.cookie = '_dd_s=isExpired=1; expires=${expires}; path=/'
+      document.cookie = '_dd_s_v2=isExpired=1; expires=${expires}; path=/'
     `
   ).catch((error) => logger.error('Error while ending session:', error))
 }

--- a/developer-extension/src/panel/components/tabs/infosTab.tsx
+++ b/developer-extension/src/panel/components/tabs/infosTab.tsx
@@ -328,7 +328,9 @@ function endSession() {
   evalInWindow(
     `
       document.cookie = '_dd_s=isExpired=1; expires=${expires}; path=/'
-      document.cookie = '_dd_s_v2=isExpired=1; expires=${expires}; path=/'
+      if (document.cookie.includes('_dd_s_v2=')) {
+        document.cookie = '_dd_s_v2=isExpired=1; expires=${expires}; path=/'
+      }
     `
   ).catch((error) => logger.error('Error while ending session:', error))
 }

--- a/developer-extension/src/panel/hooks/useSdkInfos.ts
+++ b/developer-extension/src/panel/hooks/useSdkInfos.ts
@@ -17,14 +17,14 @@ export interface SdkInfos {
     internalContext?: RumInternalContext
     globalContext?: Context
     user: Context
-    account: Context
+    account?: Context
   }
   logs?: {
     version?: string
     config?: LogsInitConfiguration
     globalContext?: Context
     user: Context
-    account: Context
+    account?: Context
   }
   cookie?: {
     id?: string

--- a/developer-extension/src/panel/hooks/useSdkInfos.ts
+++ b/developer-extension/src/panel/hooks/useSdkInfos.ts
@@ -82,6 +82,13 @@ async function getInfos(): Promise<SdkInfos> {
         // SDK v7 renamed the session cookie from '_dd_s' to '_dd_s_v2'. Only prefer the
         // new name when a v7 SDK is detected on the page, so a stale _dd_s_v2 left over
         // from a previous v7 session doesn't shadow an active v6 session.
+        //
+        // When multiple cookies share the same name (e.g. after changing
+        // trackSessionAcrossSubdomains or usePartitionedCrossSiteSessionCookie), the SDK
+        // picks the one whose 'c' marker matches its current cookie options. We replicate
+        // that formula here: c = ((domainCount << 1) | crossSite).toString(16).
+        // SESSION_COOKIE_VERSION is omitted because it is currently 0 and contributes
+        // nothing to the value.
         function findCookieValue(name) {
           return document.cookie
             .split(';')
@@ -89,8 +96,28 @@ async function getInfos(): Promise<SdkInfos> {
             .find(([cookieName]) => cookieName === name)
             ?.[1]
         }
+        function findMatchingCookieValue(name, config) {
+          const domain = config?.domain
+          const crossSite = config?.usePartitionedCrossSiteSessionCookie ? 1 : 0
+          const domainCount = domain ? domain.split('.').length - 1 : 0
+          const expectedC = ((domainCount << 1) | crossSite).toString(16)
+
+          const matches = document.cookie
+            .split(';')
+            .map(c => c.match(/(\\S*?)=(.*)/)?.slice(1) || [])
+            .filter(([cookieName]) => cookieName === name)
+            .map(([, val]) => val)
+
+          for (const val of [...matches].reverse()) {
+            const entries = Object.fromEntries(val.split('&').map(v => v.split('=')))
+            if (entries.c === expectedC) return val
+          }
+
+          return matches[0]
+        }
         const isV7 = window.DD_RUM?.version?.startsWith('7') || window.DD_LOGS?.version?.startsWith('7')
-        const cookieRawValue = isV7 ? (findCookieValue('_dd_s_v2') ?? findCookieValue('_dd_s')) : findCookieValue('_dd_s')
+        const sdkConfig = window.DD_RUM?.getInitConfiguration?.() ?? window.DD_LOGS?.getInitConfiguration?.()
+        const cookieRawValue = isV7 ? (findMatchingCookieValue('_dd_s_v2', sdkConfig) ?? findCookieValue('_dd_s')) : findCookieValue('_dd_s')
 
         const cookieEntries = cookieRawValue
           ? cookieRawValue.split('&').map((value) => value.split('='))

--- a/developer-extension/src/panel/hooks/useSdkInfos.ts
+++ b/developer-extension/src/panel/hooks/useSdkInfos.ts
@@ -79,8 +79,9 @@ async function getInfos(): Promise<SdkInfos> {
           return JSON.parse(stringified)
         }
 
-        // SDK v7 renamed the session cookie from '_dd_s' to '_dd_s_v2'. Prefer the new
-        // name and fall back to the legacy one so this works for both v6 and v7 apps.
+        // SDK v7 renamed the session cookie from '_dd_s' to '_dd_s_v2'. Only prefer the
+        // new name when a v7 SDK is detected on the page, so a stale _dd_s_v2 left over
+        // from a previous v7 session doesn't shadow an active v6 session.
         function findCookieValue(name) {
           return document.cookie
             .split(';')
@@ -88,7 +89,8 @@ async function getInfos(): Promise<SdkInfos> {
             .find(([cookieName]) => cookieName === name)
             ?.[1]
         }
-        const cookieRawValue = findCookieValue('_dd_s_v2') ?? findCookieValue('_dd_s')
+        const isV7 = window.DD_RUM?.version?.startsWith('7') || window.DD_LOGS?.version?.startsWith('7')
+        const cookieRawValue = isV7 ? (findCookieValue('_dd_s_v2') ?? findCookieValue('_dd_s')) : findCookieValue('_dd_s')
 
         const cookieEntries = cookieRawValue
           ? cookieRawValue.split('&').map((value) => value.split('='))

--- a/developer-extension/src/panel/hooks/useSdkInfos.ts
+++ b/developer-extension/src/panel/hooks/useSdkInfos.ts
@@ -17,12 +17,14 @@ export interface SdkInfos {
     internalContext?: RumInternalContext
     globalContext?: Context
     user: Context
+    account: Context
   }
   logs?: {
     version?: string
     config?: LogsInitConfiguration
     globalContext?: Context
     user: Context
+    account: Context
   }
   cookie?: {
     id?: string
@@ -31,6 +33,7 @@ export interface SdkInfos {
     logs?: string
     rum?: string
     forcedReplay?: '1'
+    anonymousId?: string
   }
   rumTrackingType?: string
   logsTrackingType?: string
@@ -76,15 +79,22 @@ async function getInfos(): Promise<SdkInfos> {
           return JSON.parse(stringified)
         }
 
-        const cookies = new Map(
-          document.cookie
+        // SDK v7 renamed the session cookie from '_dd_s' to '_dd_s_v2'. Prefer the new
+        // name and fall back to the legacy one so this works for both v6 and v7 apps.
+        function findCookieValue(name) {
+          return document.cookie
             .split(';')
-            .map(cookie => cookie.match(/(\\S*?)=(.*)/)?.slice(1))
-            .filter(cookie => cookie !== undefined)
-        );
-        const cookieRawValue = cookies.get('_dd_s_v2') ?? cookies.get('_dd_s');
-        const cookie = cookieRawValue && Object.fromEntries(
-          cookieRawValue.split('&').map(value => value.split('='))
+            .map(c => c.match(/(\\S*?)=(.*)/)?.slice(1) || [])
+            .find(([cookieName]) => cookieName === name)
+            ?.[1]
+        }
+        const cookieRawValue = findCookieValue('_dd_s_v2') ?? findCookieValue('_dd_s')
+
+        const cookieEntries = cookieRawValue
+          ? cookieRawValue.split('&').map((value) => value.split('='))
+          : null
+        const cookie = cookieEntries && Object.fromEntries(
+          cookieEntries.map(([key, val]) => (key === 'aid' ? ['anonymousId', val] : [key, val]))
         )
 
         const rum = window.DD_RUM && {
@@ -93,6 +103,7 @@ async function getInfos(): Promise<SdkInfos> {
           internalContext: window.DD_RUM?.getInternalContext?.(),
           globalContext: window.DD_RUM?.getGlobalContext?.(),
           user: window.DD_RUM?.getUser?.(),
+          account: window.DD_RUM?.getAccount?.(),
         }
 
         const logs = window.DD_LOGS && {
@@ -100,6 +111,7 @@ async function getInfos(): Promise<SdkInfos> {
           config: serializeWithFunctions(window.DD_LOGS?.getInitConfiguration?.()),
           globalContext: window.DD_LOGS?.getGlobalContext?.(),
           user: window.DD_LOGS?.getUser?.(),
+          account: window.DD_LOGS?.getAccount?.(),
         }
 
         return { rum, logs, cookie }

--- a/developer-extension/src/panel/hooks/useSdkInfos.ts
+++ b/developer-extension/src/panel/hooks/useSdkInfos.ts
@@ -79,9 +79,12 @@ async function getInfos(): Promise<SdkInfos> {
           return JSON.parse(stringified)
         }
 
-        // SDK v7 renamed the session cookie from '_dd_s' to '_dd_s_v2'. Only prefer the
-        // new name when a v7 SDK is detected on the page, so a stale _dd_s_v2 left over
-        // from a previous v7 session doesn't shadow an active v6 session.
+        // SDK v7 renamed the session cookie from '_dd_s' to '_dd_s_v2'. The SDK's own
+        // version string can't be used to tell which name is active: local dev builds
+        // always report 'dev' regardless of which major is checked out, so a v6 dev
+        // build and a v7 dev build look identical. Instead, read both cookie names and
+        // keep whichever holds the more recently created valid session, since only an
+        // actively running SDK instance writes fresh data under its own cookie name.
         //
         // When multiple cookies share the same name (e.g. after changing
         // trackSessionAcrossSubdomains or usePartitionedCrossSiteSessionCookie), the SDK
@@ -89,13 +92,6 @@ async function getInfos(): Promise<SdkInfos> {
         // that formula here: c = ((domainCount << 1) | crossSite).toString(16).
         // SESSION_COOKIE_VERSION is omitted because it is currently 0 and contributes
         // nothing to the value.
-        function findCookieValue(name) {
-          return document.cookie
-            .split(';')
-            .map(c => c.match(/(\\S*?)=(.*)/)?.slice(1) || [])
-            .find(([cookieName]) => cookieName === name)
-            ?.[1]
-        }
         function findMatchingCookieValue(name, config) {
           const domain = config?.domain
           const crossSite = config?.usePartitionedCrossSiteSessionCookie ? 1 : 0
@@ -115,9 +111,25 @@ async function getInfos(): Promise<SdkInfos> {
 
           return matches[0]
         }
-        const isV7 = window.DD_RUM?.version?.startsWith('7') || window.DD_LOGS?.version?.startsWith('7')
+        function parseSessionCookie(rawValue) {
+          if (!rawValue) {
+            return null
+          }
+          const entries = Object.fromEntries(rawValue.split('&').map((v) => v.split('=')))
+          // No 'id' means either an expired tombstone (isExpired=1) or malformed data.
+          return entries.id ? entries : null
+        }
+
         const sdkConfig = window.DD_RUM?.getInitConfiguration?.() ?? window.DD_LOGS?.getInitConfiguration?.()
-        const cookieRawValue = isV7 ? (findMatchingCookieValue('_dd_s_v2', sdkConfig) ?? findCookieValue('_dd_s')) : findCookieValue('_dd_s')
+        const v2RawValue = findMatchingCookieValue('_dd_s_v2', sdkConfig)
+        const v6RawValue = findMatchingCookieValue('_dd_s', sdkConfig)
+        const v2Session = parseSessionCookie(v2RawValue)
+        const v6Session = parseSessionCookie(v6RawValue)
+
+        const cookieRawValue =
+          v2Session && v6Session
+            ? (Number(v2Session.created) >= Number(v6Session.created) ? v2RawValue : v6RawValue)
+            : (v2RawValue ?? v6RawValue)
 
         const cookieEntries = cookieRawValue
           ? cookieRawValue.split('&').map((value) => value.split('='))


### PR DESCRIPTION
## Motivation

SDK v7 renamed the session cookie from `_dd_s` to `_dd_s_v2`, so the extension was showing empty session data for any v7 app. v7 also added an `aid` (anonymous ID) field in the cookie and a `getAccount()` API that the extension wasn't exposing. Jira: RUM-17172.

## Changes

In `useSdkInfos.ts`, cookie reading no longer tries to detect which SDK major is running. The version string can't do that reliably: local dev builds always report `version: "dev"` regardless of which major is checked out, so a v6 dev build and a v7 dev build look identical. Instead, it reads both `_dd_s` and `_dd_s_v2`, and keeps whichever holds the more recently created valid session, since only an actively running SDK writes fresh data under its own cookie name.

Both cookie names can also have duplicates under the same name (e.g. after changing `trackSessionAcrossSubdomains` or `usePartitionedCrossSiteSessionCookie`, or with v6's `betaEncodeCookieOptions`). The SDK picks the right one by matching a `c` marker encoded in the cookie value against its current config. `findMatchingCookieValue()` replicates that matching for both cookie names, so the extension doesn't just grab the first duplicate.

The `aid` cookie field is mapped to `anonymousId` for readability. Added `getAccount()` calls for both RUM and Logs.

In `infosTab.tsx`, anonymous ID shows under the cookie section, account under RUM and Logs. `endSession()` also expires `_dd_s_v2`, but only if it already exists — unconditionally writing it on a v6 page would create a phantom cookie that shadows the real v6 session on next load.

## Test instructions

1. `yarn dev`, open `http://localhost:8080`, open the Infos tab. Session data should show, including the anonymous ID.
2. `DD_RUM.setAccount({ id: 'test' })` in the console. Account should appear under RUM.
3. Click "End current session". `_dd_s_v2` should be expired in Application → Cookies, and reloading starts a new session.
4. In the console, manually write a fresh `_dd_s` (e.g. `document.cookie = '_dd_s=id=v6&created=' + Date.now() + '&expire=9999999999999; path=/'`) while a stale `_dd_s_v2` is still present. The Infos tab should now read from `_dd_s`, since it holds the more recently created session.
5. Set two `_dd_s_v2` cookies with different `c` values by hand (or reuse ones left over from changing `trackSessionAcrossSubdomains` between reloads) and confirm the extension shows the one matching the SDK's current config, not just the first one found.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file