### PR TITLE
🐛 Build test apps outside Git repositories

### DIFF
--- a/scripts/build/build-test-apps.ts
+++ b/scripts/build/build-test-apps.ts
@@ -107,7 +107,7 @@ runMain(async () => {
         if ('builderFn' in app) {
           await app.builderFn(app.name, app.options)
         } else {
-          await buildApp(app.name)
+          await buildApp(app.name, { restorePackageFiles: true })
         }
       })()
       buildPromises.set(app.name, promise)
@@ -134,35 +134,51 @@ function showHelpAndExit() {
   process.exit(0)
 }
 
-async function buildApp(appName: string) {
+async function buildApp(appName: string, { restorePackageFiles = false }: { restorePackageFiles?: boolean } = {}) {
   try {
     const appPath = `test/apps/${appName}`
     printLog(`Building app at ${appPath}...`)
-    await command`yarn install --no-immutable`.withCurrentWorkingDirectory(appPath).runAsync()
 
-    // install peer dependencies if any
-    // intent: renovate does not allow to generate local packages before install
-    // so local packages are marked as optional peer dependencies and only installed when we build the test apps
-    const packageJson = JSON.parse(fs.readFileSync(path.join(appPath, 'package.json'), 'utf-8'))
-    if (packageJson.peerDependencies) {
-      // For each peer dependency, install it
-      for (const [name] of Object.entries(packageJson.peerDependencies)) {
-        const resolution = packageJson.resolutions?.[name]
-        const specifier = resolution ? `${name}@${resolution}` : name
-        await command`yarn add -D ${specifier}`.withCurrentWorkingDirectory(appPath).runAsync()
+    await restoreFilesAfter(
+      restorePackageFiles ? ['package.json', 'yarn.lock'].map((fileName) => path.join(appPath, fileName)) : [],
+      async () => {
+        await command`yarn install --no-immutable`.withCurrentWorkingDirectory(appPath).runAsync()
+
+        // Renovate cannot generate local packages before install, so local packages are marked as optional peer dependencies.
+        // Install them only when building the test apps.
+        const packageJson = JSON.parse(fs.readFileSync(path.join(appPath, 'package.json'), 'utf-8'))
+        if (packageJson.peerDependencies) {
+          // For each peer dependency, install it
+          for (const [name] of Object.entries(packageJson.peerDependencies)) {
+            const resolution = packageJson.resolutions?.[name]
+            const specifier = resolution ? `${name}@${resolution}` : name
+            await command`yarn add -D ${specifier}`.withCurrentWorkingDirectory(appPath).runAsync()
+          }
+        }
       }
-      // revert package.json & yarn.lock changes if they are versioned
-      const areFilesVersioned = await command`git ls-files package.json yarn.lock`
-        .withCurrentWorkingDirectory(appPath)
-        .runAsync()
-      if (areFilesVersioned) {
-        await command`git checkout package.json yarn.lock`.withCurrentWorkingDirectory(appPath).runAsync()
-      }
-    }
+    )
 
     await command`yarn build`.withCurrentWorkingDirectory(appPath).runAsync()
   } catch (error) {
     throw new Error(`Failed to build app '${appName}'`, { cause: error })
+  }
+}
+
+async function restoreFilesAfter<T>(filePaths: string[], action: () => Promise<T>): Promise<T> {
+  const restoreFiles = filePaths.map((filePath) => {
+    if (fs.existsSync(filePath)) {
+      const content = fs.readFileSync(filePath)
+      return () => fs.writeFileSync(filePath, content)
+    }
+    return () => fs.rmSync(filePath, { force: true })
+  })
+
+  try {
+    return await action()
+  } finally {
+    for (const restoreFile of restoreFiles) {
+      restoreFile()
+    }
   }
 }
 


### PR DESCRIPTION
## Motivation

Developers should be able to build test applications from source archives or Jujutsu workspaces without requiring Git metadata.

## Changes

- Preserve each test app’s manifest and lockfile while installing its optional local SDK packages.
- Remove the build script’s dependency on Git commands.

## Test instructions

From a source tree without Git metadata, run:

```sh
yarn build:apps --app vanilla
```

Verify that the app builds successfully and that its `package.json` and `yarn.lock` retain their original contents.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
