### PR TITLE
👷 [PANA-8578] Update schema to support session replay string roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "woke": "scripts/cli woke"
   },
   "devDependencies": {
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=e18f1d3b6a018f00061239bf14fbfb748c9538a3",
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=131bf26801ca82202df1ef5e0124551cdb656410",
     "@eslint/js": "10.0.1",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@microsoft/api-extractor": "7.58.12",

--- a/packages/browser-core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/browser-core/src/domain/telemetry/telemetryEvent.types.ts
@@ -464,6 +464,36 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       use_remote_configuration_proxy?: boolean
       /**
+       * Metadata of the remote configuration currently applied for this session
+       */
+      remote_configuration?: {
+        /**
+         * Identifier of the remote configuration bundle this metadata belongs to
+         */
+        config_id?: string
+        /**
+         * CDN version identifier of the applied configuration
+         */
+        version_id?: string
+        /**
+         * CDN publish timestamp of the applied configuration, in ms from epoch
+         */
+        last_modified?: number
+        /**
+         * Timestamp at which the device fetched and cached this configuration version, in ms from epoch
+         */
+        last_synced?: number
+        /**
+         * Timestamp at which this configuration version was first observed as applied by the device, in ms from epoch. Stamped once and reused on every subsequent session that runs on the same version
+         */
+        first_applied?: number
+        /**
+         * Identifier of the sync that produced this configuration version, used to deduplicate repeat sessions from the same device without a persistent identifier
+         */
+        sync_id?: string
+        [k: string]: unknown
+      }
+      /**
        * The percentage of sessions with Profiling enabled
        */
       profiling_sample_rate?: number
@@ -487,6 +517,14 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        * Whether the beta track WebSockets feature is enabled
        */
       beta_track_web_sockets?: boolean
+      /**
+       * Whether tracing feature's client-side-stats generation is enabled
+       */
+      use_client_side_stats?: boolean
+      /**
+       * Whether trace sampling rules are configured
+       */
+      use_trace_sampling_rules?: boolean
       [k: string]: unknown
     }
     [k: string]: unknown
@@ -558,7 +596,7 @@ export type TelemetryBrowserFeaturesUsage =
 /**
  * Schema of mobile specific features usage
  */
-export type TelemetryMobileFeaturesUsage = TrackWebView | AndroidNetworkInstrumentation
+export type TelemetryMobileFeaturesUsage = TrackWebView | Timeseries | AndroidNetworkInstrumentation
 
 /**
  * Schema of common properties of Telemetry events
@@ -598,7 +636,7 @@ export interface CommonTelemetryProperties {
     | 'unity'
     | 'kotlin-multiplatform'
     | 'electron'
-    | 'rum-cpp'
+    | 'cpp'
     | 'maui'
   /**
    * The version of the SDK generating the telemetry event
@@ -993,6 +1031,13 @@ export interface TrackWebView {
    * trackWebView API
    */
   feature: 'trackWebView'
+  [k: string]: unknown
+}
+export interface Timeseries {
+  /**
+   * Timeseries tracking enabled
+   */
+  feature: 'timeseries'
   [k: string]: unknown
 }
 export interface AndroidNetworkInstrumentation {

--- a/packages/browser-rum-core/src/rumEvent.types.ts
+++ b/packages/browser-rum-core/src/rumEvent.types.ts
@@ -104,7 +104,7 @@ export type RumActionEvent = CommonProperties &
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
       /**
        * Is the action starting in the foreground (focus in browser)
        */
@@ -178,6 +178,9 @@ export type RumTransitionEvent = CommonProperties & {
    * RUM event type
    */
   readonly type: 'transition'
+  readonly view: {
+    [k: string]: unknown
+  }
   /**
    * Stream properties
    */
@@ -487,7 +490,7 @@ export type RumErrorEvent = CommonProperties &
     /**
      * View properties
      */
-    readonly view?: {
+    readonly view: {
       /**
        * Is the error starting in the foreground (focus in browser)
        */
@@ -536,6 +539,9 @@ export type RumLongTaskEvent = CommonProperties &
      * RUM event type
      */
     readonly type: 'long_task'
+    readonly view: {
+      [k: string]: unknown
+    }
     /**
      * Long Task properties
      */
@@ -669,6 +675,9 @@ export type RumResourceEvent = CommonProperties &
      * RUM event type
      */
     readonly type: 'resource'
+    readonly view: {
+      [k: string]: unknown
+    }
     /**
      * Resource properties
      */
@@ -825,6 +834,10 @@ export type RumResourceEvent = CommonProperties &
        */
       readonly delivery_type?: 'cache' | 'navigational-prefetch' | 'other'
       /**
+       * Whether the resource was served from the device's local cache
+       */
+      readonly local_cache_hit?: boolean
+      /**
        * The provider for this resource
        */
       readonly provider?: {
@@ -943,6 +956,9 @@ export type RumViewUpdateEvent = ViewContainerSchema &
      * RUM event type
      */
     readonly type: 'view_update'
+    readonly view: {
+      [k: string]: unknown
+    }
     [k: string]: unknown
   }
 export type RumVitalEvent = RumVitalDurationEvent | RumVitalOperationStepEvent
@@ -975,6 +991,9 @@ export type RumVitalEventCommonProperties = CommonProperties &
      * RUM event type
      */
     readonly type: 'vital'
+    readonly view: {
+      [k: string]: unknown
+    }
     /**
      * Vital properties
      */
@@ -1107,12 +1126,12 @@ export interface CommonProperties {
     | 'unity'
     | 'kotlin-multiplatform'
     | 'electron'
-    | 'rum-cpp'
+    | 'cpp'
     | 'maui'
   /**
    * View properties
    */
-  readonly view: {
+  readonly view?: {
     /**
      * UUID of the view
      */
@@ -1392,6 +1411,10 @@ export interface CommonProperties {
        * The percentage of sessions with traced resources
        */
       readonly trace_sample_rate?: number
+      /**
+       * Session Replay experimental features enabled in the SDK configuration
+       */
+      readonly session_replay_experimental_features?: string[]
       [k: string]: unknown
     }
     /**
@@ -1453,7 +1476,7 @@ export interface ViewContainerSchema {
       | 'unity'
       | 'kotlin-multiplatform'
       | 'electron'
-      | 'rum-cpp'
+      | 'cpp'
       | 'maui'
     [k: string]: unknown
   }

--- a/packages/browser-rum/src/domain/record/serialization/changeDecoder.ts
+++ b/packages/browser-rum/src/domain/record/serialization/changeDecoder.ts
@@ -114,6 +114,12 @@ function decodeChangeRecord(
         break
       }
 
+      case ChangeType.AddRoleAnnotatedStrings:
+      case ChangeType.InputValue:
+      case ChangeType.InputSelection:
+        // These change types exist in the schema, but nothing generates them yet.
+        throw new Error(`Unsupported ChangeType: ${change[0]}`)
+
       default:
         change satisfies never
         throw new Error(`Unsupported ChangeType: ${change[0] as any}`)

--- a/packages/browser-rum/src/domain/record/serialization/stringTable.ts
+++ b/packages/browser-rum/src/domain/record/serialization/stringTable.ts
@@ -1,8 +1,9 @@
+import type { StringOrStringReference } from '../../../types'
 import type { StringId } from '../itemIds'
 
 export interface StringTable {
   add(newString: string): void
-  decode(stringOrStringId: number | string): string
+  decode(value: StringOrStringReference): string
 }
 
 export function createStringTable(): StringTable {
@@ -11,13 +12,17 @@ export function createStringTable(): StringTable {
     add(newString: string): void {
       strings.set(strings.size as StringId, newString)
     },
-    decode(stringOrStringId: number | string): string {
-      if (typeof stringOrStringId === 'string') {
-        return stringOrStringId
+    decode(value: StringOrStringReference): string {
+      if (typeof value === 'string') {
+        return value // A plain string literal.
       }
-      const referencedString = strings.get(stringOrStringId as StringId)
+      if (typeof value === 'object') {
+        return value.string // A role-annotated string literal.
+      }
+
+      const referencedString = strings.get(value as StringId)
       if (referencedString === undefined) {
-        throw new Error(`Reference to unknown string: ${stringOrStringId}`)
+        throw new Error(`Reference to unknown string: ${value}`)
       }
       return referencedString
     },

--- a/packages/browser-rum/src/types/sessionReplay.ts
+++ b/packages/browser-rum/src/types/sessionReplay.ts
@@ -113,8 +113,11 @@ export type Change =
   | [8, ...AttachedStyleSheetsChange[]]
   | [9, ...MediaPlaybackStateChange[]]
   | [10, ...VisualViewportChange[]]
+  | [11, ...AddRoleAnnotatedStringsChange[]]
+  | [12, ...InputValueChange[]]
+  | [13, ...InputSelectionChange[]]
 /**
- * Browser-specific. Schema representing the addition of a string to the string table.
+ * Browser-specific. Schema representing the addition of a string to the string table, annotated as belonging to the default string role.
  */
 export type AddStringChange = string
 /**
@@ -133,7 +136,10 @@ export type AddNodeChange =
  *
  * @minItems 2
  */
-export type AddCDataSectionNodeChange = [InsertionPoint, '#cdata-section' | StringReference]
+export type AddCDataSectionNodeChange = [
+  InsertionPoint,
+  '#cdata-section' | { role: 1; string: '#cdata-section' } | StringReference,
+]
 /**
  * Browser-specific. Schema representing the insertion point of a node which is being added to the document.
  */
@@ -166,33 +172,84 @@ export type StringReference = number
  */
 export type AddDocTypeNodeChange = [
   InsertionPoint,
-  '#doctype' | StringReference,
+  '#doctype' | { role: 1; string: '#doctype' } | StringReference,
   StringOrStringReference,
   StringOrStringReference,
   StringOrStringReference,
 ]
 /**
- * Browser-specific. Schema representing a string, either expressed as a literal or as an index into the string table.
+ * Browser-specific. Schema representing a string, either expressed as a literal, as a literal with an associated string role, or as an index into the string table.
  */
-export type StringOrStringReference = string | StringReference
+export type StringOrStringReference = StringLiteral | RoleAnnotatedStringLiteral | StringReference
+/**
+ * Browser-specific. Schema representing a string, expressed as a literal.
+ */
+export type StringLiteral = string
+/**
+ * Browser-specific. Schema representing a string role.
+ */
+export type StringRoleId =
+  | StringRoleDefault
+  | StringRoleNodeName
+  | StringRoleAttributeName
+  | StringRoleAttributeValue
+  | StringRoleTextContent
+  | StringRoleFormInput
+  | StringRoleCSS
+  | StringRoleURL
+/**
+ * The default string role, used for uncategorized strings. Strings added by an AddStringChange are added to this string role.
+ */
+export type StringRoleDefault = 0
+/**
+ * A string role containing DOM node names (e.g. 'div', '#text').
+ */
+export type StringRoleNodeName = 1
+/**
+ * A string role containing DOM attribute names.
+ */
+export type StringRoleAttributeName = 2
+/**
+ * A string role containing DOM attribute values.
+ */
+export type StringRoleAttributeValue = 3
+/**
+ * A string role containing DOM text content.
+ */
+export type StringRoleTextContent = 4
+/**
+ * A string role containing DOM form input values.
+ */
+export type StringRoleFormInput = 5
+/**
+ * A string role containing CSS inline styles and stylesheets.
+ */
+export type StringRoleCSS = 6
+/**
+ * A string role containing URLs.
+ */
+export type StringRoleURL = 7
 /**
  * Schema representing the addition of a new #document node.
  *
  * @minItems 2
  */
-export type AddDocumentNodeChange = [InsertionPoint, '#document' | StringReference]
+export type AddDocumentNodeChange = [InsertionPoint, '#document' | { role: 1; string: '#document' } | StringReference]
 /**
  * Schema representing the addition of a new #document-fragment node.
  *
  * @minItems 2
  */
-export type AddDocumentFragmentNodeChange = [InsertionPoint, '#document-fragment' | StringReference]
+export type AddDocumentFragmentNodeChange = [
+  InsertionPoint,
+  '#document-fragment' | { role: 1; string: '#document-fragment' } | StringReference,
+]
 /**
  * Schema representing the addition of a new element node.
  *
  * @minItems 2
  */
-export type AddElementNodeChange = [InsertionPoint, string | StringReference, ...AttributeAssignment[]]
+export type AddElementNodeChange = [InsertionPoint, StringOrStringReference, ...AttributeAssignment[]]
 /**
  * Schema representing an assignment of a value to an attribute. The format is [name, value].
  *
@@ -204,13 +261,20 @@ export type AttributeAssignment = [StringOrStringReference, StringOrStringRefere
  *
  * @minItems 2
  */
-export type AddShadowRootNodeChange = [InsertionPoint, '#shadow-root' | StringReference]
+export type AddShadowRootNodeChange = [
+  InsertionPoint,
+  '#shadow-root' | { role: 1; string: '#shadow-root' } | StringReference,
+]
 /**
  * Schema representing the addition of a new #text node.
  *
  * @minItems 3
  */
-export type AddTextNodeChange = [InsertionPoint, '#text' | StringReference, StringOrStringReference]
+export type AddTextNodeChange = [
+  InsertionPoint,
+  '#text' | { role: 1; string: '#text' } | StringReference,
+  StringOrStringReference,
+]
 /**
  * Browser-specific. Schema representing the removal of a node from the document.
  */
@@ -338,6 +402,39 @@ export type VisualViewportHeight = number
  * The pinch-zoom scaling factor applied to the visual viewport.
  */
 export type VisualViewportScale = number
+/**
+ * Browser-specific. Schema representing the addition of a sequence of strings to the string table, annotated as belonging to a particular string role.
+ *
+ * @minItems 1
+ */
+export type AddRoleAnnotatedStringsChange = [StringRoleId, ...StringLiteral[]]
+/**
+ * Browser-specific. Schema representing a change to the value of a 'value-serializable' form input element, where 'value-serializable' means that the element's state can be reconstructed from its 'value' property.
+ *
+ * @minItems 2
+ */
+export type InputValueChange = [NodeId, StringOrStringReference]
+/**
+ * Browser-specific. Schema representing a change to the selection state of one or more 'selection-driven' form input elements; selection-driven inputs include checkboxes, radio buttons, and <select>/<option>. For <select>, the change targets the <option> elements, which allows multiple selection to be expressed naturally. To model correlated changes like updates to radio button groups, the same selection state can be applied to many nodes at once.
+ *
+ * @minItems 1
+ */
+export type InputSelectionChange = [
+  InputSelectionStateSelected | InputSelectionStateDeselected | InputSelectionStateIndeterminate,
+  ...NodeId[],
+]
+/**
+ * The element is selected. For a checkbox or radio button, this means that it is checked; for an <option>, this means that it is selected.
+ */
+export type InputSelectionStateSelected = 0
+/**
+ * The element is not selected. For a checkbox or radio button, this means that it is unchecked; for an <option>, this means that it is deselected.
+ */
+export type InputSelectionStateDeselected = 1
+/**
+ * The element is neither selected nor deselected. This state only applies to checkboxes, which render it distinctly from both the selected and deselected states.
+ */
+export type InputSelectionStateIndeterminate = 2
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
@@ -812,6 +909,13 @@ export interface CDataNode {
    */
   readonly type: 4
   textContent: ''
+}
+/**
+ * Browser-specific. Schema representing a string literal with an associated string role.
+ */
+export interface RoleAnnotatedStringLiteral {
+  role: StringRoleId
+  string: StringLiteral
 }
 /**
  * Schema of an AddedNodeMutation.

--- a/packages/browser-rum/src/types/sessionReplayConstants.ts
+++ b/packages/browser-rum/src/types/sessionReplayConstants.ts
@@ -56,6 +56,9 @@ export const ChangeType: {
   AttachedStyleSheets: ChangeTypeId<8, SessionReplay.AttachedStyleSheetsChange>
   MediaPlaybackState: ChangeTypeId<9, SessionReplay.MediaPlaybackStateChange>
   VisualViewport: ChangeTypeId<10, SessionReplay.VisualViewportChange>
+  AddRoleAnnotatedStrings: ChangeTypeId<11, SessionReplay.AddRoleAnnotatedStringsChange>
+  InputValue: ChangeTypeId<12, SessionReplay.InputValueChange>
+  InputSelection: ChangeTypeId<13, SessionReplay.InputSelectionChange>
 } = {
   AddString: 0,
   AddNode: 1,
@@ -68,6 +71,9 @@ export const ChangeType: {
   AttachedStyleSheets: 8,
   MediaPlaybackState: 9,
   VisualViewport: 10,
+  AddRoleAnnotatedStrings: 11,
+  InputValue: 12,
+  InputSelection: 13,
 } as const
 
 export type ChangeType = (typeof ChangeType)[keyof typeof ChangeType]

--- a/packages/browser-rum/test/record/elements.ts
+++ b/packages/browser-rum/test/record/elements.ts
@@ -47,8 +47,9 @@ function getElementIdsFromFullSnapshotChange(rawRecord: BrowserFullSnapshotChang
         default: {
           const [, , ...attributeAssignments] = addedNode as AddElementNodeChange
           for (const [name, value] of attributeAssignments) {
-            if (name === 'id') {
-              elementIds.set(String(value), id)
+            // Attribute names and values are always literal strings in a decoded record.
+            if (name === 'id' && typeof value === 'string') {
+              elementIds.set(value, id)
             }
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -712,10 +712,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/rum-events-format@DataDog/rum-events-format#commit=e18f1d3b6a018f00061239bf14fbfb748c9538a3":
+"@datadog/rum-events-format@DataDog/rum-events-format#commit=131bf26801ca82202df1ef5e0124551cdb656410":
   version: 0.0.0
-  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=e18f1d3b6a018f00061239bf14fbfb748c9538a3"
-  checksum: 10c0/b8306ceac7e936a517dc2cce03d9c6e0b8db9206433214d36eeae0d2e2e7089feec8c4f7c5f077eb4edf45d8abbbbbaa45808fc0a52b46c6f711e0d924221744
+  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=131bf26801ca82202df1ef5e0124551cdb656410"
+  checksum: 10c0/3633204c0e3e62e4e5b87245fd2eddd6afeb887adbd309d91790f269d7a40abbc7d16d46aeab81e1eb12a89bd000ec6036df97c2c282b27455d8a889e8661bb2
   languageName: node
   linkType: hard
 
@@ -6098,7 +6098,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "browser-sdk@workspace:."
   dependencies:
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=e18f1d3b6a018f00061239bf14fbfb748c9538a3"
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=131bf26801ca82202df1ef5e0124551cdb656410"
     "@eslint/js": "npm:10.0.1"
     "@jsdevtools/coverage-istanbul-loader": "npm:3.0.5"
     "@microsoft/api-extractor": "npm:7.58.12"


### PR DESCRIPTION
## Motivation

The `rum-events-schema` has been updated to support two new session-replay-related features:
* Strings in session replay records can now be tagged with "roles". This metadata allows us to perform transformations on recorded sessions on the backend that would be difficult to support today, including after-the-fact privacy masking.
* The relatively new "Change" data format previously didn't support incremental form input events; we fell back to the V1 format for those. A change format representation of form input events has been added. This allows the strings which appear in those events to be tagged with string roles.

Because these schema changes add new variants to existing discriminated unions, they don't type check against `main` today. We need to both update the `rum-events-schema` dependency and fix the resulting type errors.

## Changes

* The `rum-events-format` dependency has been updated to the latest commit.
* The derived types have been regenerated.
* The definitions in `sessionReplayConstants.ts` have been updated to match the shared versions in `rum-events-format`.
* A few call sites that directly interact with the new format changes have been updated to support them in a trivial way, fixing the type errors. Full implementation will come in future PRs.