### PR TITLE
🐛 fix staging-reset git pull failing with no tracking info

### DIFF
--- a/scripts/staging-ci/staging-reset.ts
+++ b/scripts/staging-ci/staging-reset.ts
@@ -26,7 +26,7 @@ runMain(async () => {
   initGitConfig(REPOSITORY)
   command`git fetch --no-tags origin ${MAIN_BRANCH} ${CURRENT_STAGING_BRANCH}`.run()
   command`git checkout ${MAIN_BRANCH} -f`.run()
-  command`git pull`.run()
+  command`git pull origin ${MAIN_BRANCH}`.run()
 
   const isNewBranch = CURRENT_STAGING_BRANCH !== NEW_STAGING_BRANCH
   if (isNewBranch) {


### PR DESCRIPTION
## Motivation

The `staging-reset-scheduled` CI job fails with `There is no tracking information for the current branch` at the bare `git pull` after checking out `main`. The script relies on the local `main` branch already having upstream tracking, which `initGitConfig` never sets (it only sets the remote URL, not branch tracking). That tracking used to be provided by the git-cache clone but is no longer present in the current runner/cache setup — the repo code is unchanged since the last successful run, only the CI image / cache layer shifted.

## Changes

- Specify the remote and branch explicitly in the `git pull` for `main` (`scripts/staging-ci/staging-reset.ts`), matching the style already used for the staging branch pull later in the same script.

## Test instructions

- The next scheduled `staging-reset-scheduled` run should pass the `git pull` step instead of failing with "no tracking information".

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
