### PR TITLE
🐛 fix staging CI scripts git pull failing with no tracking info

### DIFF
--- a/scripts/staging-ci/check-squash-into-staging.ts
+++ b/scripts/staging-ci/check-squash-into-staging.ts
@@ -30,7 +30,7 @@ runMain(() => {
 
   try {
     command`git checkout ${MAIN_BRANCH} -f`.run()
-    command`git pull`.run()
+    command`git pull origin ${MAIN_BRANCH}`.run()
     command`git merge --squash ${CI_COMMIT_SHA}`.run()
   } catch (error) {
     const diff = command`git diff`.run()
@@ -45,7 +45,7 @@ runMain(() => {
     command`git commit -am ${'squash test'}`.run()
 
     command`git checkout ${currentStaging} -f`.run()
-    command`git pull`.run()
+    command`git pull origin ${currentStaging}`.run()
     command`git merge ${MAIN_BRANCH}`.run()
   } catch (error) {
     const diff = command`git diff`.run()

--- a/scripts/staging-ci/check-staging-merge.ts
+++ b/scripts/staging-ci/check-staging-merge.ts
@@ -33,7 +33,7 @@ runMain(async () => {
 
   command`git fetch --no-tags origin ${currentStaging}`.run()
   command`git checkout ${currentStaging} -f`.run()
-  command`git pull`.run()
+  command`git pull origin ${currentStaging}`.run()
 
   printLog(
     `Checking if branch '${CI_COMMIT_REF_NAME}' (${CI_COMMIT_SHORT_SHA}) can be merged into ${currentStaging}...`


### PR DESCRIPTION
## Motivation

Follow-up to #4973: the same bare `git pull` bug exists in the other staging CI scripts.

## Changes

- Specify the remote and branch explicitly in each `git pull` call across the staging CI scripts (`check-squash-into-staging`, `check-staging-merge`), matching the style already used elsewhere in the same files.

## Test instructions

- Trigger the `check-squash-into-staging` / `check-staging-merge` CI jobs and confirm the `git pull` step no longer fails with "no tracking information".

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
