### PR TITLE
✨ Add monitorPromise and migrate .catch(monitorError) call sites

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -215,7 +215,12 @@ export default defineConfig(
       '@typescript-eslint/triple-slash-reference': ['error', { path: 'always', types: 'prefer-import', lib: 'always' }],
       '@typescript-eslint/no-floating-promises': [
         'error',
-        { allowForKnownSafeCalls: [{ from: 'package', name: ['describe', 'it', 'test'], package: 'node:test' }] },
+        {
+          allowForKnownSafeCalls: [
+            { from: 'package', name: ['describe', 'it', 'test'], package: 'node:test' },
+            'monitorPromise',
+          ],
+        },
       ],
 
       // Those lints are triggering false positives

--- a/packages/browser-core/src/browser/fetchObservable.ts
+++ b/packages/browser-core/src/browser/fetchObservable.ts
@@ -4,7 +4,7 @@ import { normalizeUrl, globalObject } from '@datadog/js-core/util'
 import type { GlobalObject } from '@datadog/js-core/util'
 import type { InstrumentedMethodCall } from '../tools/instrumentMethod'
 import { instrumentMethod } from '../tools/instrumentMethod'
-import { monitorError } from '../tools/monitor'
+import { monitorPromise } from '../tools/monitor'
 import { Observable } from '../tools/observable'
 import { readBytesFromStream } from '../tools/readBytesFromStream'
 import { tryToClone } from '../tools/utils/responseUtils'
@@ -112,7 +112,7 @@ function beforeSend(
   parameters[1] = context.init
 
   onPostCall((responsePromise) => {
-    afterSend(observable, responsePromise, context).catch(monitorError)
+    monitorPromise(afterSend(observable, responsePromise, context))
   })
 }
 

--- a/packages/browser-core/src/domain/session/sessionManager.ts
+++ b/packages/browser-core/src/domain/session/sessionManager.ts
@@ -22,7 +22,7 @@ import type { TrackingConsentState } from '../trackingConsent'
 import { display } from '../../tools/display'
 import { isSampled } from '../sampler'
 import { TelemetryMetrics, addTelemetryMetrics } from '../telemetry'
-import { monitorError } from '../../tools/monitor'
+import { monitorPromise } from '../../tools/monitor'
 import type { SessionState } from './sessionState'
 import {
   expandOnly,
@@ -99,9 +99,7 @@ export async function startSessionManager(
 
   const { throttled: throttledExpandOrRenew, cancel: cancelExpandOrRenew } = throttle(() => {
     sessionExpired = false
-    strategy
-      .setSessionState((state) => expandOrRenew(state, configuration), 'expandOrRenewOnActivity')
-      .catch(monitorError)
+    monitorPromise(strategy.setSessionState((state) => expandOrRenew(state, configuration), 'expandOrRenewOnActivity'))
   }, ONE_SECOND)
   stopCallbacks.push(cancelExpandOrRenew)
 
@@ -113,8 +111,9 @@ export async function startSessionManager(
     stopped = true
   })
 
-  let initialState = await resolveInitialState().catch((error) =>
-    monitorError(new Error(`Error while resolving initial session state: ${error}`))
+  let initialState = await monitorPromise(
+    resolveInitialState(),
+    (error) => new Error(`Error while resolving initial session state: ${String(error)}`)
   )
   if (!initialState || stopped) {
     return
@@ -130,7 +129,7 @@ export async function startSessionManager(
     if (stopped) {
       return
     }
-    initialState = await resolveInitialState().catch(monitorError)
+    initialState = await monitorPromise(resolveInitialState())
     if (!initialState || stopped) {
       return
     }
@@ -172,8 +171,8 @@ export async function startSessionManager(
     if (expireDate) {
       const delay = expireDate - dateNow()
       expirationTimeoutId = setTimeout(() => {
-        strategy
-          .setSessionState((state) => {
+        monitorPromise(
+          strategy.setSessionState((state) => {
             if (isSessionInExpiredState(state)) {
               if (!trackingConsentState.isGranted()) {
                 delete state.anonymousId
@@ -184,7 +183,7 @@ export async function startSessionManager(
 
             return state
           }, 'expireOnTimeout')
-          .catch(monitorError)
+        )
       }, delay)
     }
   }
@@ -193,9 +192,9 @@ export async function startSessionManager(
     trackingConsentState.observable.subscribe(() => {
       if (trackingConsentState.isGranted()) {
         sessionExpired = false
-        strategy
-          .setSessionState((state) => expandOrRenew(state, configuration), 'expandOrRenewOnConsent')
-          .catch(monitorError)
+        monitorPromise(
+          strategy.setSessionState((state) => expandOrRenew(state, configuration), 'expandOrRenewOnConsent')
+        )
       } else {
         expire()
       }
@@ -209,13 +208,13 @@ export async function startSessionManager(
       })
       trackVisibility(() => {
         if (!sessionExpired) {
-          strategy.setSessionState((state) => expandOnly(state), 'expandOnVisibility').catch(monitorError)
+          monitorPromise(strategy.setSessionState((state) => expandOnly(state), 'expandOnVisibility'))
         }
       })
       trackResume(() => {
-        strategy
-          .setSessionState((state) => initializeSession(state, configuration), 'initializeOnResume')
-          .catch(monitorError)
+        monitorPromise(
+          strategy.setSessionState((state) => initializeSession(state, configuration), 'initializeOnResume')
+        )
       })
     }
   }
@@ -240,7 +239,7 @@ export async function startSessionManager(
       expireObservable,
       expire,
       updateSessionState: (partialState) => {
-        strategy.setSessionState((state) => ({ ...state, ...partialState }), 'updateState').catch(monitorError)
+        monitorPromise(strategy.setSessionState((state) => ({ ...state, ...partialState }), 'updateState'))
       },
     }
   }
@@ -283,14 +282,14 @@ export async function startSessionManager(
     }
     handleStateChange(expiredState)
     // Persist to storage asynchronously
-    strategy
-      .setSessionState((state) => {
+    monitorPromise(
+      strategy.setSessionState((state) => {
         if (!trackingConsentState.isGranted()) {
           delete state.anonymousId
         }
         return getExpiredSessionState(state, configuration)
       }, 'expire')
-      .catch(monitorError)
+    )
   }
 
   function buildSessionContext(sessionState: SessionState): SessionContext {

--- a/packages/browser-core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/browser-core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -8,7 +8,7 @@ import type { SessionState } from '../sessionState'
 import { toSessionString, toSessionState } from '../sessionState'
 import { Observable } from '../../../tools/observable'
 import { mockable } from '../../../tools/mockable'
-import { monitorError } from '../../../tools/monitor'
+import { monitorPromise } from '../../../tools/monitor'
 import type { CookieAccess } from '../../../browser/cookieAccess'
 import {
   areCookiesAuthorized,
@@ -60,12 +60,12 @@ export function initCookieStrategy(
   let isFirstCall = true
 
   cookieAccess.observable.subscribe(() => {
-    cookieAccess
-      .getAll()
-      .then((cookieValues) => {
+    monitorPromise(
+      cookieAccess.getAll().then((cookieValues) => {
         sessionObservable.notify(findMatchingSessionState(cookieValues, opts))
-      })
-      .catch((error) => monitorError(new Error(`Error while reading session cookies on change: ${error}`)))
+      }),
+      (error) => new Error(`Error while reading session cookies on change: ${String(error)}`)
+    )
   })
 
   function applyAndWrite(fn: (state: SessionState) => SessionState) {

--- a/packages/browser-core/src/index.ts
+++ b/packages/browser-core/src/index.ts
@@ -44,7 +44,7 @@ export {
   addTelemetryUsage,
   addTelemetryMetrics,
 } from './domain/telemetry'
-export { monitored, monitor, callMonitored, monitorError } from './tools/monitor'
+export { monitored, monitor, callMonitored, monitorError, monitorPromise } from './tools/monitor'
 export type { Subscription } from './tools/observable'
 export { Observable, BufferedObservable } from './tools/observable'
 export type { SessionManager, SessionContext } from './domain/session/sessionManager'

--- a/packages/browser-core/src/tools/monitor.ts
+++ b/packages/browser-core/src/tools/monitor.ts
@@ -8,11 +8,11 @@ import { display } from './display'
 // mutable holder.
 let onMonitorErrorCollected: ((error: unknown) => void) | undefined
 
-const { monitored, monitor, callMonitored, monitorError } = createMonitor(display, (error) =>
+const { monitored, monitor, callMonitored, monitorError, monitorPromise } = createMonitor(display, (error) =>
   onMonitorErrorCollected?.(error)
 )
 
-export { monitored, monitor, callMonitored, monitorError }
+export { monitored, monitor, callMonitored, monitorError, monitorPromise }
 
 export function startMonitorErrorCollection(newOnMonitorErrorCollected: (error: unknown) => void) {
   onMonitorErrorCollected = newOnMonitorErrorCollected

--- a/packages/browser-logs/src/boot/preStartLogs.ts
+++ b/packages/browser-logs/src/boot/preStartLogs.ts
@@ -6,7 +6,7 @@ import {
   display,
   displayAlreadyInitializedError,
   initFeatureFlags,
-  monitorError,
+  monitorPromise,
   noop,
   buildAccountContextManager,
   CustomerContextKey,
@@ -117,8 +117,8 @@ export function createPreStartStrategy(
           ? startSessionManagerStub()
           : mockable(startSessionManager)(configuration, trackingConsentState)
 
-        void sessionManagerPromise
-          .then((newSessionManager) => {
+        monitorPromise(
+          sessionManagerPromise.then((newSessionManager) => {
             if (!newSessionManager) {
               return
             }
@@ -127,7 +127,7 @@ export function createPreStartStrategy(
             addTelemetryConfiguration(serializeLogsConfiguration(initConfiguration))
             tryStartLogs()
           })
-          .catch(monitorError)
+        )
       })
     },
 

--- a/packages/browser-rum-core/src/boot/preStartRum.ts
+++ b/packages/browser-rum-core/src/boot/preStartRum.ts
@@ -17,7 +17,7 @@ import {
   buildGlobalContextManager,
   buildUserContextManager,
   bufferContextCalls,
-  monitorError,
+  monitorPromise,
   sanitize,
   startSessionManager,
   startSessionManagerStub,
@@ -188,8 +188,8 @@ export function createPreStartStrategy(
         ? startSessionManagerStub()
         : mockable(startSessionManager)(configuration, trackingConsentState)
 
-      void sessionManagerPromise
-        .then((newSessionManager) => {
+      monitorPromise(
+        sessionManagerPromise.then((newSessionManager) => {
           if (!newSessionManager) {
             return
           }
@@ -201,7 +201,7 @@ export function createPreStartStrategy(
 
           tryStartRum()
         })
-        .catch(monitorError)
+      )
     })
   }
 
@@ -251,13 +251,15 @@ export function createPreStartStrategy(
         const isSyncLoading = !!initConfiguration.remoteConfigurationId || !!initConfiguration.remoteConfiguration?.sync
 
         if (isSyncLoading) {
-          fetchAndApplyRemoteConfiguration(initConfiguration, supportedContextManagers)
-            .then((resolvedInitConfiguration) => {
-              if (resolvedInitConfiguration) {
-                doInit(resolvedInitConfiguration, errorStack)
+          monitorPromise(
+            fetchAndApplyRemoteConfiguration(initConfiguration, supportedContextManagers).then(
+              (resolvedInitConfiguration) => {
+                if (resolvedInitConfiguration) {
+                  doInit(resolvedInitConfiguration, errorStack)
+                }
               }
-            })
-            .catch(monitorError)
+            )
+          )
         } else {
           const resolvedInitConfiguration = getRemoteConfiguration(initConfiguration, supportedContextManagers)
 

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
@@ -5,7 +5,7 @@ import {
   getCookie,
   addTelemetryMetrics,
   TelemetryMetrics,
-  monitorError,
+  monitorPromise,
   fetch,
 } from '@datadog/browser-core'
 import { isIndexableObject } from '@datadog/js-core/util'
@@ -346,21 +346,22 @@ function doBackgroundCacheSync(
   cache: ReturnType<typeof createConfigurationCache>,
   metrics: ReturnType<typeof initMetrics>
 ) {
-  fetchRemoteConfiguration(initConfiguration)
-    .then((fetchResult) => {
-      if (!fetchResult.ok) {
-        metrics.increment('fetch', 'failure')
-        display.error(fetchResult.error)
-      } else {
-        metrics.increment('fetch', 'success')
-        cache.write(fetchResult.value)
-      }
-    })
-    .catch(monitorError)
-    .finally(() => {
-      // monitor-until: forever
-      addTelemetryMetrics(TelemetryMetrics.REMOTE_CONFIGURATION_METRIC_NAME, { metrics: metrics.get() })
-    })
+  monitorPromise(
+    fetchRemoteConfiguration(initConfiguration)
+      .then((fetchResult) => {
+        if (!fetchResult.ok) {
+          metrics.increment('fetch', 'failure')
+          display.error(fetchResult.error)
+        } else {
+          metrics.increment('fetch', 'success')
+          cache.write(fetchResult.value)
+        }
+      })
+      .finally(() => {
+        // monitor-until: forever
+        addTelemetryMetrics(TelemetryMetrics.REMOTE_CONFIGURATION_METRIC_NAME, { metrics: metrics.get() })
+      })
+  )
 }
 
 export function getRemoteConfiguration(

--- a/packages/browser-rum/src/boot/postStartStrategy.ts
+++ b/packages/browser-rum/src/boot/postStartStrategy.ts
@@ -1,7 +1,7 @@
 import type { LifeCycle, RumConfiguration, StartRecordingOptions, ViewHistory } from '@datadog/browser-rum-core'
 import { LifeCycleEventType, SessionReplayState, computeSessionReplayState } from '@datadog/browser-rum-core'
 import type { Telemetry, DeflateEncoder, SessionManager } from '@datadog/browser-core'
-import { asyncRunOnReadyState, monitorError, Observable } from '@datadog/browser-core'
+import { asyncRunOnReadyState, monitorPromise, Observable } from '@datadog/browser-core'
 import { getSessionReplayLink } from '../domain/getSessionReplayLink'
 import { startRecorderInitTelemetry } from '../domain/startRecorderInitTelemetry'
 import type { startRecording } from './datadogRecorder'
@@ -121,7 +121,7 @@ export function createPostStartStrategy(
     const forced = shouldForceReplay(replayState, options) || false
 
     // Intentionally not awaiting doStart() to keep it asynchronous
-    doStart(forced).catch(monitorError)
+    monitorPromise(doStart(forced))
 
     if (forced) {
       sessionManager.updateSessionState({ forcedReplay: '1' })

--- a/packages/browser-rum/src/boot/profilerApi.ts
+++ b/packages/browser-rum/src/boot/profilerApi.ts
@@ -7,7 +7,7 @@ import {
   correctedChildSampleRate,
   isSampled,
   mockable,
-  monitorError,
+  monitorPromise,
 } from '@datadog/browser-core'
 import type { RUMProfiler } from '../domain/profiling/types'
 import { isProfilingSupported } from '../domain/profiling/profilingSupported'
@@ -49,8 +49,8 @@ export function makeProfilerApi(): ProfilerApi {
       return
     }
 
-    mockable(lazyLoadProfiler)()
-      .then((createRumProfiler) => {
+    monitorPromise(
+      mockable(lazyLoadProfiler)().then((createRumProfiler) => {
         if (!createRumProfiler) {
           profilingContextManager.set({ status: 'error', error_reason: 'failed-to-lazy-load' })
           return
@@ -67,7 +67,7 @@ export function makeProfilerApi(): ProfilerApi {
         )
         profiler.start()
       })
-      .catch(monitorError)
+    )
   }
 
   return {

--- a/packages/browser-rum/src/domain/profiling/datadogProfiler.ts
+++ b/packages/browser-rum/src/domain/profiling/datadogProfiler.ts
@@ -8,7 +8,7 @@ import {
   clearTimeout,
   setTimeout,
   DOM_EVENT,
-  monitorError,
+  monitorPromise,
   display,
   mockable,
   isSampled,
@@ -133,8 +133,8 @@ export function createRumProfiler(
     const checkGeneration = ++quotaCheckGeneration
     const sessionId = session.findTrackedSession()?.id
     if (sessionId) {
-      mockable(checkProfilingQuota)(configuration, sessionId)
-        .then((result) => {
+      monitorPromise(
+        mockable(checkProfilingQuota)(configuration, sessionId).then((result) => {
           if (checkGeneration !== quotaCheckGeneration) {
             return
           }
@@ -145,7 +145,7 @@ export function createRumProfiler(
             stopProfiling('quota_ko', result.reason)
           }
         })
-        .catch(monitorError)
+      )
     }
   }
 
@@ -275,9 +275,8 @@ export function createRumProfiler(
     const { startClocks, views, sessionId } = runningInstance
 
     // Stop current profiler to get trace
-    runningInstance.profiler
-      .stop()
-      .then((trace) => {
+    monitorPromise(
+      runningInstance.profiler.stop().then((trace) => {
         const endClocks = clocksNow()
         const duration = elapsed(startClocks.relative, endClocks.relative)
         const longTasks = longTaskHistory.findAll(startClocks.relative, duration)
@@ -311,7 +310,7 @@ export function createRumProfiler(
           sessionId
         )
       })
-      .catch(monitorError)
+    )
   }
 
   function stopProfilerInstance(stateReason: RumProfilerStoppedInstance['stateReason']) {
@@ -343,7 +342,7 @@ export function createRumProfiler(
       clearTimeout(runningInstance.timeoutId)
       // eslint-disable-next-line local-rules/disallow-zone-js-patched-values -- FIXME use the `addEventListener` helper
       runningInstance.profiler.removeEventListener('samplebufferfull', handleSampleBufferFull)
-      void runningInstance.profiler.stop().catch(monitorError)
+      monitorPromise(runningInstance.profiler.stop())
     } else {
       // Collect and send profile data in background - doesn't block state transitions
       collectProfilerInstance(runningInstance)

--- a/packages/js-core/api/monitor.api.md
+++ b/packages/js-core/api/monitor.api.md
@@ -16,6 +16,7 @@ export interface Monitor {
     monitor: <T extends (...args: any[]) => unknown>(fn: T) => T;
     monitored: <T extends (...params: any[]) => unknown>(_: any, __: string, descriptor: TypedPropertyDescriptor<T>) => void;
     monitorError: (e: unknown) => void;
+    monitorPromise: <T>(promise: Promise<T>, mapError?: (error: unknown) => unknown) => Promise<T | undefined>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/js-core/src/entries/monitor.spec.ts
+++ b/packages/js-core/src/entries/monitor.spec.ts
@@ -136,6 +136,29 @@ describe('monitor', () => {
         expect(onMonitorErrorCollectedSpy).toHaveBeenCalledOnceWith(new Error('error'))
       })
     })
+
+    describe('monitorPromise', () => {
+      it('resolves with the original value when the promise fulfills', async () => {
+        const result = await currentMonitor.monitorPromise(Promise.resolve(42))
+        expect(result).toEqual(42)
+      })
+
+      it('reports the rejection and resolves to undefined', async () => {
+        const result = await currentMonitor.monitorPromise(Promise.reject(new Error('rejected')))
+
+        expect(result).toBeUndefined()
+        expect(onMonitorErrorCollectedSpy).toHaveBeenCalledOnceWith(new Error('rejected'))
+      })
+
+      it('transforms the rejection via mapError before reporting', async () => {
+        await currentMonitor.monitorPromise(
+          Promise.reject(new Error('original')),
+          (error) => new Error(`wrapped: ${String(error)}`)
+        )
+
+        expect(onMonitorErrorCollectedSpy).toHaveBeenCalledOnceWith(new Error('wrapped: Error: original'))
+      })
+    })
   })
 
   describe('debug logging', () => {
@@ -171,6 +194,14 @@ describe('monitor', () => {
 
       expect(displayErrorSpy).toHaveBeenCalledWith('[MONITOR]', new Error('message'))
       expect(displayErrorSpy).toHaveBeenCalledWith('[MONITOR]', new Error('unexpected'))
+    })
+
+    it('logs rejected promises to the display when debug mode is enabled', async () => {
+      setDebugMode(true)
+
+      await currentMonitor.monitorPromise(Promise.reject(new Error('message')))
+
+      expect(displayErrorSpy).toHaveBeenCalledWith('[MONITOR]', new Error('message'))
     })
   })
 })

--- a/packages/js-core/src/entries/monitor.ts
+++ b/packages/js-core/src/entries/monitor.ts
@@ -77,17 +77,47 @@ export interface Monitor {
    * but can also be called to report an error caught elsewhere.
    *
    * When to use: prefer this when you **already hold an error value** and only need to route it to
-   * telemetry — e.g. a promise rejection, which `monitor`/`callMonitored` do not catch (they only
-   * handle synchronous throws).
+   * telemetry. For promise rejections, prefer {@link Monitor.monitorPromise} over
+   * `.catch(monitorError)` — `monitor`/`callMonitored` only catch synchronous throws, and
+   * `monitorPromise` keeps the swallow-rejection semantics explicit.
    *
    * @param e - The error to report.
+   */
+  monitorError: (e: unknown) => void
+
+  /**
+   * Routes a promise rejection to telemetry, mirroring how {@link Monitor.monitor} captures the
+   * active context for callbacks: attach it to a promise the SDK owns and any rejection is
+   * reported (via the error callback) instead of surfacing as an unhandled rejection.
+   *
+   * **Swallows the rejection** after reporting it, returning a promise that resolves to `undefined`
+   * (matching {@link Monitor.callMonitored}'s on-throw return). Because of this, use it **only for
+   * promises the SDK owns end-to-end** — never for promises handed back to customer code, where
+   * swallowing would hide the rejection from the caller.
+   *
+   * When to use: prefer this over `.catch(monitorError)` for SDK-internal async work (fetch
+   * pipelines, session persistence, remote configuration, profiling). `monitor`/`callMonitored`
+   * only catch synchronous throws, so promise rejections need this helper.
+   *
+   * @param promise - The promise to monitor.
+   * @param mapError - Optional transform applied to the rejection before it is reported (e.g. to
+   * wrap a low-level error in a descriptive `new Error(...)`). When omitted the rejection is
+   * reported as-is. The transform runs inside the rejection handler, so it sees the original
+   * error.
+   * @returns A promise that resolves with the original value, or to `undefined` if the input
+   * rejected (the rejection is reported and swallowed).
    * @example
    * ```ts
    * // route a promise rejection to telemetry
-   * doAsyncThing().catch(monitorError)
+   * monitorPromise(doAsyncThing())
+   *
+   * // wrap the rejection in a descriptive error before reporting
+   * monitorPromise(resolveInitialState(), (error) =>
+   *   new Error(`Error while resolving initial session state: ${error}`)
+   * )
    * ```
    */
-  monitorError: (e: unknown) => void
+  monitorPromise: <T>(promise: Promise<T>, mapError?: (error: unknown) => unknown) => Promise<T | undefined>
 }
 
 /**
@@ -151,10 +181,15 @@ export function createMonitor(display: Display, onMonitorErrorCollected: (error:
     }
   }
 
+  function monitorPromise<T>(promise: Promise<T>, mapError?: (error: unknown) => unknown): Promise<T | undefined> {
+    return promise.catch((e) => monitorError(mapError ? mapError(e) : e)) as Promise<T | undefined>
+  }
+
   return {
     monitored,
     monitor,
     callMonitored,
     monitorError,
+    monitorPromise,
   }
 }


### PR DESCRIPTION
## Motivation

Promise rejections from SDK-internal async work (session persistence, fetch pipelines, remote configuration, profiling) are currently routed to telemetry via `.catch(monitorError)`. This pattern has two gaps that block the upcoming monitor-context-propagation rework:

- It can't capture the SDK context at call time, so once the context mechanism lands, rejections firing asynchronously would have no active context and wouldn't route to the originating SDK's telemetry.
- Sites that wrap the error in a descriptive `new Error(...)` require a custom `.catch` handler, fragmenting the pattern.

## Changes

- **Add `monitorPromise` to the `Monitor` interface** in `@datadog/js-core/monitor`: reports a rejection to telemetry and swallows it (resolves to `undefined`), mirroring `callMonitored`'s on-throw return. An optional `mapError` argument transforms the rejection before reporting, replacing the custom `.catch` handlers that wrapped errors in descriptive messages.
- **Migrate all 19 `.catch(monitorError)` call sites** across `browser-core`, `browser-rum-core`, `browser-rum`, and `browser-logs` to `monitorPromise(...)`, including the two wrapped-error sites.
- **Allow `monitorPromise` as a known-safe floating call** in the `@typescript-eslint/no-floating-promises` lint rule, so terminal call sites read naturally without a `void` prefix.
- Re-export `monitorPromise` through `@datadog/browser-core`.

This is an additive, behavior-preserving change: today `monitorPromise` is just `promise.catch(monitorError)`. It lays the groundwork so the later context-aware version can capture the active SDK context at call time without touching call sites again.

## Test instructions

- Run the sandbox (`yarn dev`) and trigger an async code path that rejects (e.g. block the intake endpoint so a fetch rejects, or force a session-store write failure). Confirm the rejection is still reported to telemetry and does not surface as an unhandled rejection in the console.
- With debug mode enabled (`debug: true` in the init config), confirm rejected-promise errors still log `[MONITOR] ...` to the console.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file