### PR TITLE
♻️ [PANA-8578] Record form input using change operations

### DIFF
--- a/packages/browser-rum/src/domain/record/record.spec.ts
+++ b/packages/browser-rum/src/domain/record/record.spec.ts
@@ -7,12 +7,11 @@ import type {
   AddNodeChange,
   BrowserChangeRecord,
   BrowserIncrementalSnapshotRecord,
-  BrowserMutationData,
   BrowserRecord,
   Change,
   ScrollData,
 } from '../../types'
-import { ChangeType, RecordType, IncrementalSource, SnapshotFormat } from '../../types'
+import { ChangeType, InputSelectionState, RecordType, IncrementalSource, SnapshotFormat } from '../../types'
 import { appendElement } from '../../../../browser-rum-core/test'
 import { getReplayStats } from '../replayStats'
 import type { RecordAPI } from './record'
@@ -213,11 +212,10 @@ describe('record', () => {
 
       recordApi.flushMutations()
 
-      const innerMutationData = getLastIncrementalSnapshotData<BrowserMutationData & { isChecked: boolean }>(
-        getEmittedRecords(),
-        IncrementalSource.Input
-      )
-      expect(innerMutationData.isChecked).toBe(true)
+      expect(getLastChangeOfType(ChangeType.InputSelection, getEmittedRecords())).toEqual([
+        ChangeType.InputSelection,
+        [InputSelectionState.Selected, jasmine.any(Number)],
+      ])
     })
 
     it('should record the change event inside a shadow root only once, regardless if the DOM is serialized multiple times', () => {
@@ -231,7 +229,8 @@ describe('record', () => {
       radio.dispatchEvent(createNewEvent('change', { target: radio, composed: false }))
 
       const inputRecords = getEmittedRecords().filter(
-        (record) => record.type === RecordType.IncrementalSnapshot && record.data.source === IncrementalSource.Input
+        (record) =>
+          record.type === RecordType.Change && record.data.some((change) => change[0] === ChangeType.InputSelection)
       )
 
       expect(inputRecords.length).toBe(1)
@@ -371,8 +370,9 @@ describe('record', () => {
       input.value = 'newValue'
       input.dispatchEvent(createNewEvent('input', { target: input }))
 
-      expect(getEmittedRecords()[0].type).toBe(RecordType.IncrementalSnapshot)
-      expect((getEmittedRecords()[0] as BrowserIncrementalSnapshotRecord).data.source).toBe(IncrementalSource.Input)
+      const record = emitSpy.calls.mostRecent().args[0]
+      expect(record.type).toBe(RecordType.Change)
+      expect((record as BrowserChangeRecord).data.map((change) => change[0])).toContain(ChangeType.InputValue)
     })
 
     it('media interaction', () => {

--- a/packages/browser-rum/src/domain/record/record.ts
+++ b/packages/browser-rum/src/domain/record/record.ts
@@ -76,7 +76,7 @@ export function record(options: RecordOptions): RecordAPI {
     trackMouseInteraction(processRecord, scope),
     trackScroll(document, processRecord, scope),
     trackViewportResize(processRecord),
-    trackInput(document, processRecord, scope),
+    trackInput(document, processRecord, emitStats, scope),
     trackMediaInteraction(processRecord, scope),
     trackStyleSheet(processRecord, scope),
     trackFocus(processRecord),

--- a/packages/browser-rum/src/domain/record/serialization/changeDecoder.ts
+++ b/packages/browser-rum/src/domain/record/serialization/changeDecoder.ts
@@ -10,6 +10,7 @@ import type {
   BrowserChangeRecord,
   BrowserFullSnapshotChangeRecord,
   Change,
+  InputValueChange,
   StyleSheetRules,
   TextChange,
 } from '../../../types'
@@ -66,6 +67,10 @@ function decodeChangeRecord(
         // Deliberately don't include this change in the decoded record.
         break
 
+      case ChangeType.AddRoleAnnotatedStrings:
+        // This change type exists in the schema, but nothing generates it yet.
+        throw new Error(`Unsupported ChangeType: ${change[0]}`)
+
       case ChangeType.AddNode: {
         const decoded: [typeof ChangeType.AddNode, ...AddNodeChange[]] = [ChangeType.AddNode]
         for (let i = 1; i < change.length; i++) {
@@ -97,11 +102,21 @@ function decodeChangeRecord(
         break
       }
 
+      case ChangeType.InputValue: {
+        const decoded: [typeof ChangeType.InputValue, ...InputValueChange[]] = [ChangeType.InputValue]
+        for (let i = 1; i < change.length; i++) {
+          decoded.push(decodeInputValueChange(change[i] as InputValueChange, stringTable))
+        }
+        decodedData.push(decoded)
+        break
+      }
+
       case ChangeType.Size:
       case ChangeType.ScrollPosition:
       case ChangeType.AttachedStyleSheets:
       case ChangeType.MediaPlaybackState:
       case ChangeType.VisualViewport:
+      case ChangeType.InputSelection:
         decodedData.push(change)
         break
 
@@ -113,12 +128,6 @@ function decodeChangeRecord(
         decodedData.push(decoded)
         break
       }
-
-      case ChangeType.AddRoleAnnotatedStrings:
-      case ChangeType.InputValue:
-      case ChangeType.InputSelection:
-        // These change types exist in the schema, but nothing generates them yet.
-        throw new Error(`Unsupported ChangeType: ${change[0]}`)
 
       default:
         change satisfies never
@@ -185,6 +194,10 @@ function decodeAttributeChange(change: AttributeChange, stringTable: StringTable
 }
 
 function decodeTextChange(change: TextChange, stringTable: StringTable): TextChange {
+  return [change[0], stringTable.decode(change[1])]
+}
+
+function decodeInputValueChange(change: InputValueChange, stringTable: StringTable): InputValueChange {
   return [change[0], stringTable.decode(change[1])]
 }
 

--- a/packages/browser-rum/src/domain/record/serialization/changeEncoder.spec.ts
+++ b/packages/browser-rum/src/domain/record/serialization/changeEncoder.spec.ts
@@ -211,6 +211,8 @@ describe('ChangeEncoder', () => {
       encoder.add(ChangeType.AddStyleSheet, [['rule1']])
       encoder.add(ChangeType.ScrollPosition, [0, 10, 20])
       encoder.add(ChangeType.Size, [0, 100, 200])
+      encoder.add(ChangeType.InputSelection, [0, 1])
+      encoder.add(ChangeType.InputValue, [0, 'value'])
       encoder.add(ChangeType.Text, [0, 'text'])
       encoder.add(ChangeType.Attribute, [0, ['id', 'test']])
       encoder.add(ChangeType.RemoveNode, 1)
@@ -227,6 +229,8 @@ describe('ChangeEncoder', () => {
         ChangeType.RemoveNode,
         ChangeType.Attribute,
         ChangeType.Text,
+        ChangeType.InputValue,
+        ChangeType.InputSelection,
         ChangeType.Size,
         ChangeType.ScrollPosition,
         ChangeType.AddStyleSheet,

--- a/packages/browser-rum/src/domain/record/serialization/changeEncoder.ts
+++ b/packages/browser-rum/src/domain/record/serialization/changeEncoder.ts
@@ -75,6 +75,8 @@ export function createChangeEncoder(stringIds: StringIds): ChangeEncoder {
       ChangeType.RemoveNode,
       ChangeType.Attribute,
       ChangeType.Text,
+      ChangeType.InputValue,
+      ChangeType.InputSelection,
       ChangeType.Size,
       ChangeType.ScrollPosition,
       ChangeType.AddStyleSheet,

--- a/packages/browser-rum/src/domain/record/serialization/serializationTransaction.ts
+++ b/packages/browser-rum/src/domain/record/serialization/serializationTransaction.ts
@@ -12,6 +12,8 @@ import type {
   AddTextNodeChange,
   AttachedStyleSheetsChange,
   AttributeChange,
+  InputSelectionChange,
+  InputSelectionState,
   InsertionPoint,
   MediaInteractionType,
   StyleSheetMediaList,
@@ -84,6 +86,12 @@ export interface SerializationTransaction {
   /** Set a node's attributes to the given values. */
   setAttributes(change: AttributeChange): void
 
+  /** Set the selection state of one or more checkboxes, radio buttons, or <option> elements. */
+  setInputSelection(state: InputSelectionState, nodeIds: NodeId[]): void
+
+  /** Set the value of a form element. */
+  setInputValue(nodeId: NodeId, value: string): void
+
   /** Set the media playback state of an <audio> or <video> element. */
   setMediaPlaybackState(nodeId: NodeId, state: MediaInteractionType): void
 
@@ -142,6 +150,16 @@ export function serializeInTransaction(
     },
     setAttributes(change: AttributeChange): void {
       encoder.add(ChangeType.Attribute, change)
+    },
+    setInputSelection(state: InputSelectionState, nodeIds: NodeId[]): void {
+      const change: InputSelectionChange = [state]
+      for (const nodeId of nodeIds) {
+        change.push(nodeId)
+      }
+      encoder.add(ChangeType.InputSelection, change)
+    },
+    setInputValue(nodeId: NodeId, value: string): void {
+      encoder.add(ChangeType.InputValue, [nodeId, value])
     },
     setMediaPlaybackState(nodeId: NodeId, state: MediaInteractionType): void {
       encoder.add(ChangeType.MediaPlaybackState, [nodeId, state])

--- a/packages/browser-rum/src/domain/record/shadowRootsController.ts
+++ b/packages/browser-rum/src/domain/record/shadowRootsController.ts
@@ -30,7 +30,7 @@ export const initShadowRootsController = (
       }
       const mutationTracker = trackMutation(shadowRoot, emitRecord, emitStats, scope)
       // The change event does not bubble up across the shadow root, we have to listen on the shadow root
-      const inputTracker = trackInput(shadowRoot, emitRecord, scope)
+      const inputTracker = trackInput(shadowRoot, emitRecord, emitStats, scope)
       // The scroll event does not bubble up across the shadow root, we have to listen on the shadow root
       const scrollTracker = trackScroll(shadowRoot, emitRecord, scope)
       controllerByShadowRoot.set(shadowRoot, {

--- a/packages/browser-rum/src/domain/record/trackers/trackInput.spec.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackInput.spec.ts
@@ -1,152 +1,431 @@
-import { DefaultPrivacyLevel } from '@datadog/browser-core'
-import type { Clock } from '@datadog/browser-core/test'
-import { createNewEvent, mockClock, registerCleanupTask } from '@datadog/browser-core/test'
+import { DefaultPrivacyLevel, noop } from '@datadog/browser-core'
+import { createNewEvent, registerCleanupTask } from '@datadog/browser-core/test'
+import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT } from '@datadog/browser-rum-core'
-import { appendElement } from '../../../../../browser-rum-core/test'
-import type { EmitRecordCallback } from '../record.types'
+import type { BrowserChangeRecord, BrowserRecord } from '../../../types'
+import { ChangeType, InputSelectionState } from '../../../types'
+import type { NodeId } from '../itemIds'
 import type { RecordingScope } from '../recordingScope'
-import type { BrowserIncrementalSnapshotRecord, InputData } from '../../../types'
-import { IncrementalSource, RecordType } from '../../../types'
-import { takeFullSnapshotForTesting } from '../test/serialization.specHelper'
-import { createRecordingScopeForTesting } from '../test/recordingScope.specHelper'
+import type { ChangeDecoder, SerializationStats } from '../serialization'
+import { serializeHtml } from '../test/serializeHtml.specHelper'
 import { trackInput } from './trackInput'
-import type { Tracker } from './tracker.types'
 
 describe('trackInput', () => {
-  let inputTracker: Tracker
-  let emitRecordCallback: jasmine.Spy<EmitRecordCallback>
-  let input: HTMLInputElement
-  let clock: Clock | undefined
-  let scope: RecordingScope
+  describe('<input type="text">', () => {
+    it('records the value when an "input" event is dispatched', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(
+        '<input type="text" />',
+        (input: HTMLElement) => {
+          input.dispatchEvent(createNewEvent('input', { target: input }))
+        },
+        { beforeTracking: (input: HTMLElement) => setValue(input, 'foo') }
+      )
 
-  beforeEach(() => {
-    input = appendElement('<div><input target /></div>') as HTMLInputElement
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([[ChangeType.InputValue, [nodeIdOf(sandbox), 'foo']]])
+    })
 
-    emitRecordCallback = jasmine.createSpy()
-    scope = createRecordingScopeForTesting()
-    takeFullSnapshotForTesting(scope)
+    it('records the value when the value property is set', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn('<input type="text" />', (input: HTMLElement) => {
+        setValue(input, 'foo')
+      })
 
-    registerCleanupTask(() => {
-      inputTracker.stop()
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([[ChangeType.InputValue, [nodeIdOf(sandbox), 'foo']]])
+    })
+
+    it('does not record the value a second time when it has not changed', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(
+        '<input type="text" />',
+        async (input: HTMLElement) => {
+          await actAndWaitForInstrumentation(() => {
+            setValue(input, 'foo')
+          })
+
+          input.dispatchEvent(createNewEvent('input', { target: input }))
+        }
+      )
+
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([[ChangeType.InputValue, [nodeIdOf(sandbox), 'foo']]])
+    })
+
+    // An event cannot be dispatched from inside a shadow root directly, because events with
+    // `isTrusted: false` do not cross the shadow root boundary.
+    it('records a composed event against the element it was composed from', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(
+        '<input type="text" />',
+        (input: HTMLElement) => {
+          const document = input.ownerDocument
+          const host = document.createElement('div')
+          host.attachShadow({ mode: 'open' })
+
+          const event = createNewEvent('input', { target: host, composed: true })
+          event.composedPath = () => [input, host, document.body]
+          input.dispatchEvent(event)
+        },
+        { beforeTracking: (input: HTMLElement) => setValue(input, 'foo') }
+      )
+
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([[ChangeType.InputValue, [nodeIdOf(sandbox), 'foo']]])
     })
   })
 
-  function getLatestInputPayload(): InputData & { text?: string } {
-    const latestRecord = emitRecordCallback.calls.mostRecent()?.args[0] as BrowserIncrementalSnapshotRecord
-    return latestRecord.data as InputData
-  }
+  describe('<textarea>', () => {
+    it('records the value when an "input" event is dispatched', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(
+        '<textarea></textarea>',
+        (textarea: HTMLElement) => {
+          textarea.dispatchEvent(createNewEvent('input', { target: textarea }))
+        },
+        { beforeTracking: (textarea: HTMLElement) => setValue(textarea, 'several lines') }
+      )
 
-  it('collects input values when an "input" event is dispatched', () => {
-    inputTracker = trackInput(document, emitRecordCallback, scope)
-    dispatchInputEvent('foo')
-
-    expect(emitRecordCallback).toHaveBeenCalledOnceWith({
-      type: RecordType.IncrementalSnapshot,
-      timestamp: jasmine.any(Number),
-      data: {
-        source: IncrementalSource.Input,
-        text: 'foo',
-        id: jasmine.any(Number) as unknown as number,
-      },
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([[ChangeType.InputValue, [nodeIdOf(sandbox), 'several lines']]])
     })
   })
 
-  it('collects input values when a property setter is used', () => {
-    clock = mockClock()
-    inputTracker = trackInput(document, emitRecordCallback, scope)
-    input.value = 'foo'
+  describe('<select>', () => {
+    const TWO_OPTIONS = '<select><option value="a">a</option><option value="b">b</option></select>'
 
-    clock.tick(0)
+    it('records the selected <option>, not the <select>', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(
+        TWO_OPTIONS,
+        (select: HTMLElement) => {
+          select.dispatchEvent(createNewEvent('change', { target: select }))
+        },
+        { beforeTracking: (select: HTMLElement) => setValue(select, 'b') }
+      )
 
-    expect(emitRecordCallback).toHaveBeenCalledOnceWith({
-      type: RecordType.IncrementalSnapshot,
-      timestamp: jasmine.any(Number),
-      data: {
-        source: IncrementalSource.Input,
-        text: 'foo',
-        id: jasmine.any(Number) as unknown as number,
-      },
+      const [, b] = Array.from(sandbox.querySelectorAll('option'))
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([[ChangeType.InputSelection, [InputSelectionState.Selected, nodeIdOf(b)]]])
+    })
+
+    it('does not record the previously selected <option> being deselected', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(TWO_OPTIONS, async (select: HTMLElement) => {
+        await actAndWaitForInstrumentation(() => {
+          setValue(select, 'b')
+          select.dispatchEvent(createNewEvent('change', { target: select }))
+        })
+
+        setValue(select, 'a')
+        select.dispatchEvent(createNewEvent('change', { target: select }))
+      })
+
+      // Selecting an <option> implicitly deselects the one selected before it, so each change
+      // records the newly selected <option> and nothing else.
+      const [a, b] = Array.from(sandbox.querySelectorAll('option'))
+      expect(changes.length).toBe(2)
+      expect(changes[0].data).toEqual([[ChangeType.InputSelection, [InputSelectionState.Selected, nodeIdOf(b)]]])
+      expect(changes[1].data).toEqual([[ChangeType.InputSelection, [InputSelectionState.Selected, nodeIdOf(a)]]])
+    })
+
+    it('records an <option> being selected again after another one was selected', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(TWO_OPTIONS, async (select: HTMLElement) => {
+        for (const value of ['b', 'a', 'b']) {
+          await actAndWaitForInstrumentation(() => {
+            setValue(select, value)
+            select.dispatchEvent(createNewEvent('change', { target: select }))
+          })
+        }
+      })
+
+      const [, b] = Array.from(sandbox.querySelectorAll('option'))
+      expect(changes.length).toBe(3)
+      expect(changes[2].data).toEqual([[ChangeType.InputSelection, [InputSelectionState.Selected, nodeIdOf(b)]]])
+    })
+
+    it('does not record the same <option> being selected twice', async () => {
+      const { changes } = await recordInputIn(TWO_OPTIONS, async (select: HTMLElement) => {
+        await actAndWaitForInstrumentation(() => {
+          setValue(select, 'b')
+          select.dispatchEvent(createNewEvent('change', { target: select }))
+        })
+
+        select.dispatchEvent(createNewEvent('change', { target: select }))
+      })
+
+      expect(changes.length).toBe(1)
     })
   })
 
-  it('does not invoke callback when the value does not change', () => {
-    clock = mockClock()
-    inputTracker = trackInput(document, emitRecordCallback, scope)
-    input.value = 'foo'
-    clock.tick(0)
+  describe('<input type="checkbox">', () => {
+    it('records the checkbox becoming selected', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(
+        '<input type="checkbox" />',
+        (checkbox: HTMLElement) => {
+          checkbox.dispatchEvent(createNewEvent('change', { target: checkbox }))
+        },
+        { beforeTracking: (checkbox: HTMLElement) => setChecked(checkbox, true) }
+      )
 
-    dispatchInputEvent('foo')
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([[ChangeType.InputSelection, [InputSelectionState.Selected, nodeIdOf(sandbox)]]])
+    })
 
-    expect(emitRecordCallback).toHaveBeenCalledTimes(1)
-  })
+    it('records the checkbox becoming deselected', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(
+        '<input type="checkbox" checked />',
+        (checkbox: HTMLElement) => {
+          checkbox.dispatchEvent(createNewEvent('change', { target: checkbox }))
+        },
+        { beforeTracking: (checkbox: HTMLElement) => setChecked(checkbox, false) }
+      )
 
-  it('does not instrument setters when observing a shadow DOM', () => {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const originalSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set
-    const host = document.createElement('div')
-    host.attachShadow({ mode: 'open' })
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([
+        [ChangeType.InputSelection, [InputSelectionState.Deselected, nodeIdOf(sandbox)]],
+      ])
+    })
 
-    inputTracker = trackInput(host.shadowRoot!, emitRecordCallback, scope)
+    it('records the selection state when the checked property is set', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(
+        '<input type="checkbox" />',
+        (checkbox: HTMLElement) => {
+          setChecked(checkbox, true)
+        }
+      )
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set).toBe(originalSetter)
-  })
-
-  // cannot trigger an event in a Shadow DOM because event with `isTrusted:false` do not cross the root
-  it('collects input values when an "input" event is composed', () => {
-    inputTracker = trackInput(document, emitRecordCallback, scope)
-    dispatchInputEventWithInShadowDom('foo')
-
-    expect(emitRecordCallback).toHaveBeenCalledOnceWith({
-      type: RecordType.IncrementalSnapshot,
-      timestamp: jasmine.any(Number),
-      data: {
-        source: IncrementalSource.Input,
-        text: 'foo',
-        id: jasmine.any(Number) as unknown as number,
-      },
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([[ChangeType.InputSelection, [InputSelectionState.Selected, nodeIdOf(sandbox)]]])
     })
   })
 
-  it('masks input values according to the element privacy level', () => {
-    inputTracker = trackInput(document, emitRecordCallback, scope)
-    input.setAttribute(PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT)
+  describe('<input type="radio">', () => {
+    it('records the rest of the group being deselected alongside the selected button', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(
+        `<div>
+          <input type="radio" name="group" checked />
+          <input type="radio" name="group" />
+          <input type="radio" name="group" />
+        </div>`,
+        (container: HTMLElement) => {
+          const [, second] = Array.from(container.querySelectorAll('input'))
+          second.dispatchEvent(createNewEvent('change', { target: second }))
+        },
+        {
+          // Checking a radio button is what a browser does to the group before it dispatches the
+          // 'change' event on the button that the user selected.
+          beforeTracking: (container: HTMLElement) => {
+            const [first, second] = Array.from(container.querySelectorAll('input'))
+            first.checked = false
+            second.checked = true
+          },
+        }
+      )
 
-    dispatchInputEvent('foo')
-
-    expect(getLatestInputPayload().text).toBe('***')
+      // The whole group changes to the same state, so it is recorded as a single change that
+      // applies that state to every node in it.
+      const [first, second, third] = Array.from(sandbox.querySelectorAll('input'))
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([
+        [
+          ChangeType.InputSelection,
+          [InputSelectionState.Selected, nodeIdOf(second)],
+          [InputSelectionState.Deselected, nodeIdOf(first), nodeIdOf(third)],
+        ],
+      ])
+    })
   })
 
-  it('masks input values according to a parent element privacy level', () => {
-    inputTracker = trackInput(document, emitRecordCallback, scope)
-    input.parentElement!.setAttribute(PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT)
+  describe('privacy', () => {
+    it('masks the value according to the privacy level of the element', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(
+        `<input type="text" ${PRIVACY_ATTR_NAME}="${PRIVACY_ATTR_VALUE_MASK_USER_INPUT}" />`,
+        (input: HTMLElement) => {
+          input.dispatchEvent(createNewEvent('input', { target: input }))
+        },
+        { beforeTracking: (input: HTMLElement) => setValue(input, 'foo') }
+      )
 
-    dispatchInputEvent('foo')
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([[ChangeType.InputValue, [nodeIdOf(sandbox), '***']]])
+    })
 
-    expect(getLatestInputPayload().text).toBe('***')
+    it('masks the value according to the privacy level of an ancestor', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(
+        `<div ${PRIVACY_ATTR_NAME}="${PRIVACY_ATTR_VALUE_MASK_USER_INPUT}"><input type="text" /></div>`,
+        (container: HTMLElement) => {
+          const input = container.querySelector('input')!
+          input.dispatchEvent(createNewEvent('input', { target: input }))
+        },
+        { beforeTracking: (container: HTMLElement) => setValue(container.querySelector('input')!, 'foo') }
+      )
+
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([[ChangeType.InputValue, [nodeIdOf(sandbox.querySelector('input')!), '***']]])
+    })
+
+    it('masks the value according to the default privacy level', async () => {
+      const { changes, nodeIdOf, sandbox } = await recordInputIn(
+        '<input type="text" />',
+        (input: HTMLElement) => {
+          input.dispatchEvent(createNewEvent('input', { target: input }))
+        },
+        {
+          beforeTracking: (input: HTMLElement) => setValue(input, 'foo'),
+          configuration: { defaultPrivacyLevel: DefaultPrivacyLevel.MASK },
+        }
+      )
+
+      expect(changes.length).toBe(1)
+      expect(changes[0].data).toEqual([[ChangeType.InputValue, [nodeIdOf(sandbox), '***']]])
+    })
+
+    it('records nothing at all for a masked <select>', async () => {
+      // A selection state has nothing that can stand in for the selected <option> the way '***'
+      // stands in for a value, so a masked <select> records nothing rather than giving away
+      // which option was picked.
+      const { changes, emitStats } = await recordInputIn(
+        '<select><option value="a">a</option><option value="b">b</option></select>',
+        (select: HTMLElement) => {
+          select.dispatchEvent(createNewEvent('change', { target: select }))
+        },
+        {
+          beforeTracking: (select: HTMLElement) => setValue(select, 'b'),
+          configuration: { defaultPrivacyLevel: DefaultPrivacyLevel.MASK },
+        }
+      )
+
+      expect(changes).toEqual([])
+      expect(emitStats).not.toHaveBeenCalled()
+    })
+
+    it('records nothing at all for a masked checkbox', async () => {
+      const { changes, emitStats } = await recordInputIn(
+        '<input type="checkbox" />',
+        (checkbox: HTMLElement) => {
+          checkbox.dispatchEvent(createNewEvent('change', { target: checkbox }))
+        },
+        {
+          beforeTracking: (checkbox: HTMLElement) => setChecked(checkbox, true),
+          configuration: { defaultPrivacyLevel: DefaultPrivacyLevel.MASK },
+        }
+      )
+
+      expect(changes).toEqual([])
+      expect(emitStats).not.toHaveBeenCalled()
+    })
   })
 
-  it('masks input values according to a the default privacy level', () => {
-    scope = createRecordingScopeForTesting({ configuration: { defaultPrivacyLevel: DefaultPrivacyLevel.MASK } })
-    takeFullSnapshotForTesting(scope)
-    inputTracker = trackInput(document, emitRecordCallback, scope)
+  describe('when tracking a shadow root', () => {
+    it('does not instrument property setters', async () => {
+      const { sandbox, scope } = await createSandbox('<div></div>')
+      const view = sandbox.ownerDocument.defaultView!
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const originalSetter = Object.getOwnPropertyDescriptor(view.HTMLInputElement.prototype, 'value')!.set
 
-    dispatchInputEvent('foo')
+      const inputTracker = trackInput(sandbox.attachShadow({ mode: 'open' }), noop, noop, scope)
+      registerCleanupTask(() => {
+        inputTracker.stop()
+      })
 
-    expect(getLatestInputPayload().text).toBe('***')
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(Object.getOwnPropertyDescriptor(view.HTMLInputElement.prototype, 'value')!.set).toBe(originalSetter)
+    })
   })
-
-  function dispatchInputEvent(newValue: string) {
-    input.value = newValue
-    input.dispatchEvent(createNewEvent('input', { target: input }))
-  }
-
-  function dispatchInputEventWithInShadowDom(newValue: string) {
-    input.value = newValue
-    const host = document.createElement('div')
-    host.attachShadow({ mode: 'open' })
-    const event = createNewEvent('input', { target: host, composed: true })
-    event.composedPath = () => [input, host, input.parentElement!, document.body]
-    input.dispatchEvent(event)
-  }
 })
+
+/**
+ * Serializes the given HTML in an isolated iframe, so that the elements under test have node
+ * ids, and returns the sandbox along with the state needed to track input in it. The sandbox
+ * is the outermost element of the HTML.
+ */
+async function createSandbox(
+  html: string,
+  configuration?: Partial<RumConfiguration>
+): Promise<{ sandbox: HTMLElement; scope: RecordingScope; decoder: ChangeDecoder }> {
+  let captured: { sandbox: HTMLElement; scope: RecordingScope; decoder: ChangeDecoder } | undefined
+
+  const fullSnapshot = await serializeHtml(html, {
+    configuration,
+    after(target: Node, scope: RecordingScope, _stats: SerializationStats, decoder: ChangeDecoder): void {
+      captured = { sandbox: target as HTMLElement, scope, decoder }
+    },
+  })
+
+  if (!fullSnapshot || !captured) {
+    throw new Error('Expected a full snapshot to be recorded')
+  }
+  return captured
+}
+
+/**
+ * Serializes the given HTML in an isolated iframe, tracks input in it, and runs `interaction`
+ * against the sandbox. Returns the change records that were recorded, decoded in the order
+ * they were emitted, and the spy standing in for the stats callback.
+ *
+ * Use the `beforeTracking` option to put the sandbox into the state a browser would have put
+ * it in before it dispatched the event under test. Assigning to a property inside
+ * `interaction` instead would go through the instrumented property setters, which record a
+ * change of their own and would mask whatever the event listener does or doesn't record.
+ */
+async function recordInputIn(
+  html: string,
+  interaction: (sandbox: HTMLElement) => void | Promise<void>,
+  {
+    beforeTracking,
+    configuration,
+  }: {
+    beforeTracking?: (sandbox: HTMLElement) => void
+    configuration?: Partial<RumConfiguration>
+  } = {}
+): Promise<{
+  changes: BrowserChangeRecord[]
+  nodeIdOf: (node: Node) => NodeId
+  sandbox: HTMLElement
+  emitStats: jasmine.Spy
+}> {
+  const { sandbox, scope, decoder } = await createSandbox(html, configuration)
+
+  beforeTracking?.(sandbox)
+
+  const changes: BrowserChangeRecord[] = []
+  const emitRecord = (record: BrowserRecord): void => {
+    changes.push(decoder.decode(record as BrowserChangeRecord))
+  }
+  const emitStats = jasmine.createSpy('emitStats')
+
+  const inputTracker = trackInput(sandbox.ownerDocument, emitRecord, emitStats, scope)
+  registerCleanupTask(() => {
+    inputTracker.stop()
+  })
+
+  await actAndWaitForInstrumentation(() => interaction(sandbox))
+
+  return {
+    changes,
+    nodeIdOf: (node: Node) => nodeIdOf(node, scope),
+    sandbox,
+    emitStats,
+  }
+}
+
+function nodeIdOf(node: Node, scope: RecordingScope): NodeId {
+  const nodeId = scope.nodeIds.get(node)
+  if (nodeId === undefined) {
+    throw new Error('Node was not serialized')
+  }
+  return nodeId
+}
+
+function setValue(element: HTMLElement, value: string) {
+  ;(element as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).value = value
+}
+
+function setChecked(element: HTMLElement, checked: boolean) {
+  ;(element as HTMLInputElement).checked = checked
+}
+
+async function actAndWaitForInstrumentation(action: () => Promise<void> | void): Promise<void> {
+  await action()
+
+  // `instrumentSetter()` runs instrumentation at the next macrotask. Wait until the
+  // instrumentation has run.
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+}

--- a/packages/browser-rum/src/domain/record/trackers/trackInput.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackInput.ts
@@ -1,23 +1,50 @@
 import { instrumentSetter, DOM_EVENT, addEventListeners, noop } from '@datadog/browser-core'
+import { timeStampNow } from '@datadog/js-core/time'
 import { NodePrivacyLevel, getNodePrivacyLevel, shouldMaskNode } from '@datadog/browser-rum-core'
-import { IncrementalSource } from '../../../types'
-import type { InputData, InputState } from '../../../types'
+import { InputSelectionState } from '../../../types'
 import { getEventTarget } from '../eventsUtils'
+import type { NodeId } from '../itemIds'
 import type { RecordingScope } from '../recordingScope'
-import { getElementInputValue } from '../serialization'
-import { assembleIncrementalSnapshot } from '../assembly'
-import type { EmitRecordCallback } from '../record.types'
+import type { SerializationTransaction } from '../serialization'
+import { getElementInputValue, SerializationKind, serializeInTransaction } from '../serialization'
+import type { EmitRecordCallback, EmitStatsCallback } from '../record.types'
 import type { Tracker } from './tracker.types'
+
+const enum InputStateType {
+  VALUE,
+  SELECTION,
+}
+
+/**
+ * The state of a form element: either a value, for an element whose state can be
+ * reconstructed from its `value` property, or a selection state, for an element the user
+ * selects rather than fills in.
+ */
+type InputState =
+  { type: InputStateType.VALUE; value: string } | { type: InputStateType.SELECTION; selection: InputSelectionState }
+
+/** The state every radio button of a group but the selected one changes to. */
+const DESELECTED_INPUT_STATE: InputState = {
+  type: InputStateType.SELECTION,
+  selection: InputSelectionState.Deselected,
+}
 
 export function trackInput(
   target: Document | ShadowRoot,
   emitRecord: EmitRecordCallback,
+  emitStats: EmitStatsCallback,
   scope: RecordingScope
 ): Tracker {
   const defaultPrivacyLevel = scope.configuration.defaultPrivacyLevel
   const lastInputStateMap: WeakMap<Node, InputState> = new WeakMap()
 
-  const isShadowRoot = target !== document
+  const isShadowRoot = target.nodeType !== target.DOCUMENT_NODE
+
+  const targetGlobal = (isShadowRoot ? (target as ShadowRoot).ownerDocument : (target as Document)).defaultView
+  if (!targetGlobal) {
+    // A document with no global object, such as one created by DOMParser, produces no input events.
+    return { stop: noop }
+  }
 
   const { stop: stopEventListeners } = addEventListeners(
     target,
@@ -28,9 +55,9 @@ export function trackInput(
     (event) => {
       const target = getEventTarget(event)
       if (
-        target instanceof HTMLInputElement ||
-        target instanceof HTMLTextAreaElement ||
-        target instanceof HTMLSelectElement
+        target instanceof targetGlobal.HTMLInputElement ||
+        target instanceof targetGlobal.HTMLTextAreaElement ||
+        target instanceof targetGlobal.HTMLSelectElement
       ) {
         onElementChange(target)
       }
@@ -44,11 +71,11 @@ export function trackInput(
   let stopPropertySetterInstrumentation: () => void
   if (!isShadowRoot) {
     const instrumentationStoppers = [
-      instrumentSetter(HTMLInputElement.prototype, 'value', onElementChange),
-      instrumentSetter(HTMLInputElement.prototype, 'checked', onElementChange),
-      instrumentSetter(HTMLSelectElement.prototype, 'value', onElementChange),
-      instrumentSetter(HTMLTextAreaElement.prototype, 'value', onElementChange),
-      instrumentSetter(HTMLSelectElement.prototype, 'selectedIndex', onElementChange),
+      instrumentSetter(targetGlobal.HTMLInputElement.prototype, 'value', onElementChange),
+      instrumentSetter(targetGlobal.HTMLInputElement.prototype, 'checked', onElementChange),
+      instrumentSetter(targetGlobal.HTMLSelectElement.prototype, 'value', onElementChange),
+      instrumentSetter(targetGlobal.HTMLTextAreaElement.prototype, 'value', onElementChange),
+      instrumentSetter(targetGlobal.HTMLSelectElement.prototype, 'selectedIndex', onElementChange),
     ]
     stopPropertySetterInstrumentation = () => {
       instrumentationStoppers.forEach((stopper) => stopper.stop())
@@ -72,56 +99,134 @@ export function trackInput(
 
     const type = target.type
 
+    // The changed node. Usually the target; for <select>, the now-selected <option>.
+    let changedNode: Node = target
     let inputState: InputState
     if (type === 'radio' || type === 'checkbox') {
       if (shouldMaskNode(target, nodePrivacyLevel)) {
         return
       }
-      inputState = { isChecked: (target as HTMLInputElement).checked }
+      inputState = { type: InputStateType.SELECTION, selection: selectionStateOf(target as HTMLInputElement) }
+    } else if (isSelectElement(target)) {
+      if (shouldMaskNode(target, nodePrivacyLevel)) {
+        return
+      }
+      // TODO: Record every selected <option> of a <select multiple>, not just the first.
+      const selectedOption = target.options[target.selectedIndex]
+      if (!selectedOption) {
+        return
+      }
+      changedNode = selectedOption
+      inputState = { type: InputStateType.SELECTION, selection: InputSelectionState.Selected }
     } else {
       const value = getElementInputValue(target, nodePrivacyLevel)
       if (value === undefined) {
         return
       }
-      inputState = { text: value }
+      inputState = { type: InputStateType.VALUE, value }
     }
 
-    // Can be multiple changes on the same node within the same batched mutation observation.
-    createRecordIfStateChanged(target, inputState)
+    const changedNodeId = affectedNodeIdForChange(changedNode, inputState)
 
-    // If a radio was checked, other radios with the same name attribute will be unchecked.
-    const name = target.name
-    if (type === 'radio' && name && (target as HTMLInputElement).checked) {
-      document.querySelectorAll(`input[type="radio"][name="${CSS.escape(name)}"]`).forEach((el: Element) => {
-        if (el !== target) {
-          // TODO: Consider the privacy implications for various differing input privacy levels
-          createRecordIfStateChanged(el, { isChecked: false })
+    // Selecting a radio button deselects every other radio button in its group.
+    const deselectedNodeIds: NodeId[] = []
+    if (type === 'radio' && (target as HTMLInputElement).checked) {
+      forEachOtherRadioInGroup(target as HTMLInputElement, (radio: HTMLInputElement) => {
+        // TODO: Consider the privacy implications for various differing input privacy levels
+        const deselectedNodeId = affectedNodeIdForChange(radio, DESELECTED_INPUT_STATE)
+        if (deselectedNodeId !== undefined) {
+          deselectedNodeIds.push(deselectedNodeId)
         }
       })
     }
+
+    if (isSelectElement(target)) {
+      // Update the state of now-deselected options.
+      // TODO: Record the deselections once <select multiple> is supported.
+      for (let i = 0; i < target.options.length; i++) {
+        const option = target.options[i]
+        if (option !== changedNode) {
+          lastInputStateMap.delete(option)
+        }
+      }
+    }
+
+    if (changedNodeId === undefined && deselectedNodeIds.length === 0) {
+      return
+    }
+
+    serializeInTransaction(
+      SerializationKind.INCREMENTAL_SNAPSHOT,
+      emitRecord,
+      emitStats,
+      scope,
+      timeStampNow(),
+      (transaction: SerializationTransaction) => {
+        if (changedNodeId !== undefined) {
+          if (inputState.type === InputStateType.VALUE) {
+            transaction.setInputValue(changedNodeId, inputState.value)
+          } else {
+            transaction.setInputSelection(inputState.selection, [changedNodeId])
+          }
+        }
+        if (deselectedNodeIds.length > 0) {
+          transaction.setInputSelection(InputSelectionState.Deselected, deselectedNodeIds)
+        }
+      }
+    )
   }
 
   /**
-   * There can be multiple changes on the same node within the same batched mutation observation.
+   * Given a form input change, returns the affected node id, if any. It's possible for
+   * there to be no affected node id if the change was redundant, or if the node has not
+   * yet been snapshotted (in which case a future snapshot will pick up the change
+   * instead), or if the node is not being recorded due to its privacy level.
    */
-  function createRecordIfStateChanged(target: Node, inputState: InputState) {
+  function affectedNodeIdForChange(target: Node, inputState: InputState): NodeId | undefined {
     const id = scope.nodeIds.get(target)
     if (id === undefined) {
-      return
+      return undefined
     }
     const lastInputState = lastInputStateMap.get(target)
-    if (
-      !lastInputState ||
-      (lastInputState as { text?: string }).text !== (inputState as { text?: string }).text ||
-      (lastInputState as { isChecked?: boolean }).isChecked !== (inputState as { isChecked?: boolean }).isChecked
-    ) {
-      lastInputStateMap.set(target, inputState)
-      emitRecord(
-        assembleIncrementalSnapshot<InputData>(IncrementalSource.Input, {
-          id,
-          ...inputState,
-        })
-      )
+    if (lastInputState && isSameInputState(lastInputState, inputState)) {
+      return undefined
     }
+    lastInputStateMap.set(target, inputState)
+    return id
   }
+}
+
+function isSelectElement(element: Element): element is HTMLSelectElement {
+  return element.tagName === 'SELECT'
+}
+
+/** The selection state of a checkbox or radio button. */
+function selectionStateOf(input: HTMLInputElement): InputSelectionState {
+  // TODO: Record indeterminate checkboxes as InputSelectionState.Indeterminate.
+  return input.checked ? InputSelectionState.Selected : InputSelectionState.Deselected
+}
+
+/** Runs the given callback for every other radio button in the same group as the given one. */
+function forEachOtherRadioInGroup(radio: HTMLInputElement, callback: (radio: HTMLInputElement) => void): void {
+  if (!radio.name) {
+    // A radio button with no name isn't part of a group at all.
+    return
+  }
+
+  // TODO: Correctly scope by form and shadow tree.
+  radio.ownerDocument
+    .querySelectorAll(`input[type="radio"][name="${CSS.escape(radio.name)}"]`)
+    .forEach((element: Element) => {
+      const otherRadio = element as HTMLInputElement
+      if (otherRadio !== radio) {
+        callback(otherRadio)
+      }
+    })
+}
+
+function isSameInputState(a: InputState, b: InputState): boolean {
+  if (a.type === InputStateType.VALUE) {
+    return b.type === InputStateType.VALUE && a.value === b.value
+  }
+  return b.type === InputStateType.SELECTION && a.selection === b.selection
 }

--- a/packages/browser-rum/src/types/sessionReplayConstants.ts
+++ b/packages/browser-rum/src/types/sessionReplayConstants.ts
@@ -78,6 +78,19 @@ export const ChangeType: {
 
 export type ChangeType = (typeof ChangeType)[keyof typeof ChangeType]
 
+/** The selection state of a checkbox, radio button, or `<option>`. */
+export const InputSelectionState: {
+  Selected: SessionReplay.InputSelectionStateSelected
+  Deselected: SessionReplay.InputSelectionStateDeselected
+  Indeterminate: SessionReplay.InputSelectionStateIndeterminate
+} = {
+  Selected: 0,
+  Deselected: 1,
+  Indeterminate: 2,
+} as const
+
+export type InputSelectionState = (typeof InputSelectionState)[keyof typeof InputSelectionState]
+
 export const PlaybackState: {
   Playing: SessionReplay.PlaybackStatePlaying
   Paused: SessionReplay.PlaybackStatePaused

--- a/packages/browser-rum/test/record/changes.ts
+++ b/packages/browser-rum/test/record/changes.ts
@@ -1,5 +1,11 @@
-import type { BrowserChangeRecord, BrowserFullSnapshotChangeRecord, BrowserRecord } from '../../src/types'
-import { RecordType, SnapshotFormat } from '../../src/types'
+import type {
+  BrowserChangeRecord,
+  BrowserFullSnapshotChangeRecord,
+  BrowserRecord,
+  InputSelectionChange,
+  InputValueChange,
+} from '../../src/types'
+import { ChangeType, RecordType, SnapshotFormat } from '../../src/types'
 import { createChangeDecoder } from '../../src/domain/record'
 
 export function decodeChangeRecords(
@@ -24,4 +30,55 @@ export function findChangeRecords(
       record.type === RecordType.Change ||
       (record.type === RecordType.FullSnapshot && record.format === SnapshotFormat.Change)
   )
+}
+
+/**
+ * The InputValue changes recorded for the given node id, in the order they were recorded. The
+ * records must already be decoded, so that the recorded values are literal strings.
+ */
+export function findInputValues(
+  records: Array<BrowserChangeRecord | BrowserFullSnapshotChangeRecord>,
+  nodeId: number
+): string[] {
+  const values: string[] = []
+  for (const change of findChangesOfType(records, ChangeType.InputValue)) {
+    const [changedNodeId, value] = change as InputValueChange
+    if (changedNodeId === nodeId) {
+      values.push(value as string)
+    }
+  }
+  return values
+}
+
+/**
+ * The selection states recorded for the given node id by InputSelection changes, in the order
+ * they were recorded.
+ */
+export function findInputSelections(
+  records: Array<BrowserChangeRecord | BrowserFullSnapshotChangeRecord>,
+  nodeId: number
+): number[] {
+  const states: number[] = []
+  for (const change of findChangesOfType(records, ChangeType.InputSelection)) {
+    const [state, ...nodeIds] = change as InputSelectionChange
+    if (nodeIds.indexOf(nodeId) >= 0) {
+      states.push(state)
+    }
+  }
+  return states
+}
+
+function findChangesOfType(
+  records: Array<BrowserChangeRecord | BrowserFullSnapshotChangeRecord>,
+  type: ChangeType
+): unknown[] {
+  const changesOfType: unknown[] = []
+  for (const record of records) {
+    for (const change of record.data) {
+      if (change[0] === type) {
+        changesOfType.push(...change.slice(1))
+      }
+    }
+  }
+  return changesOfType
 }

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -1,9 +1,14 @@
-import type { InputData, StyleSheetRuleData, ScrollData } from '@datadog/browser-rum/src/types'
-import { IncrementalSource, ChangeType, RecordType } from '@datadog/browser-rum/src/types'
+import type { StyleSheetRuleData, ScrollData } from '@datadog/browser-rum/src/types'
+import { IncrementalSource, ChangeType, InputSelectionState, RecordType } from '@datadog/browser-rum/src/types'
 
 import { DefaultPrivacyLevel, SESSION_STORE_KEY } from '@datadog/browser-core'
 
-import { decodeChangeRecords, findChangeRecords } from '@datadog/browser-rum/test/record/changes'
+import {
+  decodeChangeRecords,
+  findChangeRecords,
+  findInputSelections,
+  findInputValues,
+} from '@datadog/browser-rum/test/record/changes'
 import {
   getElementIdsFromFullSnapshot,
   getScrollPositionsFromFullSnapshot,
@@ -339,8 +344,8 @@ test.describe('recorder', () => {
           </label>
           <label for="select">
             <select name="" id="select">
-              <option value="1">1</option>
-              <option value="2">2</option>
+              <option value="1" id="select-option-1">1</option>
+              <option value="2" id="select-option-2">2</option>
             </select>
           </label>
         </form>
@@ -365,47 +370,41 @@ test.describe('recorder', () => {
 
         const fullSnapshot = findFullSnapshot({ records: intakeRegistry.replayRecords })!
         const elementIds = getElementIdsFromFullSnapshot(fullSnapshot)
+        const changeRecords = decodeChangeRecords(findChangeRecords(intakeRegistry.replayRecords))
 
-        const textInputRecords = filterRecordsByIdAttribute('text-input')
-        expect(textInputRecords.length).toBeGreaterThanOrEqual(4)
-        expect((textInputRecords[textInputRecords.length - 1].data as { text?: string }).text).toBe('test')
+        const textInputValues = valuesRecordedFor('text-input')
+        expect(textInputValues.length).toBeGreaterThanOrEqual(4)
+        expect(textInputValues.at(-1)).toBe('test')
 
-        const radioInputRecords = filterRecordsByIdAttribute('radio-input')
-        expect(radioInputRecords).toHaveLength(1)
-        expect((radioInputRecords[0].data as { text?: string }).text).toBe(undefined)
-        expect((radioInputRecords[0].data as { isChecked?: boolean }).isChecked).toBe(true)
+        expect(selectionsRecordedFor('radio-input')).toEqual([InputSelectionState.Selected])
 
-        const checkboxInputRecords = filterRecordsByIdAttribute('checkbox-input')
-        expect(checkboxInputRecords).toHaveLength(1)
-        expect((checkboxInputRecords[0].data as { text?: string }).text).toBe(undefined)
-        expect((checkboxInputRecords[0].data as { isChecked?: boolean }).isChecked).toBe(true)
+        expect(selectionsRecordedFor('checkbox-input')).toEqual([InputSelectionState.Selected])
 
-        const textareaRecords = filterRecordsByIdAttribute('textarea')
-        expect(textareaRecords.length).toBeGreaterThanOrEqual(4)
-        expect((textareaRecords[textareaRecords.length - 1].data as { text?: string }).text).toBe('textarea test')
+        const textareaValues = valuesRecordedFor('textarea')
+        expect(textareaValues.length).toBeGreaterThanOrEqual(4)
+        expect(textareaValues.at(-1)).toBe('textarea test')
 
-        const selectRecords = filterRecordsByIdAttribute('select')
-        expect(selectRecords).toHaveLength(1)
-        expect((selectRecords[0].data as { text?: string }).text).toBe('2')
+        expect(valuesRecordedFor('select')).toEqual([])
+        expect(selectionsRecordedFor('select-option-1')).toEqual([])
+        expect(selectionsRecordedFor('select-option-2')).toEqual([InputSelectionState.Selected])
 
-        function filterRecordsByIdAttribute(idAttribute: string) {
-          const id = elementIds.get(idAttribute)
-          const records = findAllIncrementalSnapshots(
-            { records: intakeRegistry.replayRecords },
-            IncrementalSource.Input
-          ) as Array<{ data: InputData }>
-          return records.filter((record) => record.data.id === id)
+        function valuesRecordedFor(idAttribute: string) {
+          return findInputValues(changeRecords, elementIds.get(idAttribute)!)
+        }
+
+        function selectionsRecordedFor(idAttribute: string) {
+          return findInputSelections(changeRecords, elementIds.get(idAttribute)!)
         }
       })
 
-    createTest("don't record ignored input interactions")
+    createTest('mask input interactions of elements marked as user input')
       .withRum({
         defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
       })
       .withBody(html`
         <input type="text" id="first" name="first" />
-        <input type="text" id="second" name="second" data-dd-privacy="input-ignored" />
-        <input type="text" id="third" name="third" class="dd-privacy-input-ignored" />
+        <input type="text" id="second" name="second" data-dd-privacy="mask-user-input" />
+        <input type="text" id="third" name="third" class="dd-privacy-mask-user-input" />
         <input type="password" id="fourth" name="fourth" />
       `)
       .run(async ({ intakeRegistry, flushEvents, page }) => {
@@ -423,13 +422,20 @@ test.describe('recorder', () => {
 
         await flushEvents()
 
-        const inputRecords = findAllIncrementalSnapshots(
-          { records: intakeRegistry.replayRecords },
-          IncrementalSource.Input
-        )
+        const fullSnapshot = findFullSnapshot({ records: intakeRegistry.replayRecords })!
+        const elementIds = getElementIdsFromFullSnapshot(fullSnapshot)
+        const changeRecords = decodeChangeRecords(findChangeRecords(intakeRegistry.replayRecords))
 
-        expect(inputRecords.length).toBeGreaterThanOrEqual(3) // 4 on Safari, 3 on others
-        expect((inputRecords[inputRecords.length - 1].data as { text?: string }).text).toBe('***')
+        // #second and #third are marked as user input, by attribute and by class name; a
+        // password input is masked whatever the privacy level says. #first is recorded as typed.
+        expect(lastValueRecordedFor('first')).toBe('foo')
+        expect(lastValueRecordedFor('second')).toBe('***')
+        expect(lastValueRecordedFor('third')).toBe('***')
+        expect(lastValueRecordedFor('fourth')).toBe('***')
+
+        function lastValueRecordedFor(idAttribute: string) {
+          return findInputValues(changeRecords, elementIds.get(idAttribute)!).at(-1)
+        }
       })
 
     createTest('replace masked values by asterisks')
@@ -449,15 +455,15 @@ test.describe('recorder', () => {
 
         expect(intakeRegistry.replaySegments).toHaveLength(1)
 
-        const segment = intakeRegistry.replaySegments[0]
+        const fullSnapshot = findFullSnapshot({ records: intakeRegistry.replayRecords })!
+        const elementIds = getElementIdsFromFullSnapshot(fullSnapshot)
+        const changeRecords = decodeChangeRecords(findChangeRecords(intakeRegistry.replaySegments[0].records))
 
-        const inputRecords = findAllIncrementalSnapshots(segment, IncrementalSource.Input)
-
-        expect(inputRecords.length).toBeGreaterThan(0)
-
-        expect(inputRecords.every((inputRecord) => /^\**$/.test((inputRecord.data as { text: string }).text))).toBe(
-          true
-        )
+        for (const idAttribute of ['by-data-attribute', 'by-classname']) {
+          const values = findInputValues(changeRecords, elementIds.get(idAttribute)!)
+          expect(values.length).toBeGreaterThan(0)
+          expect(values.every((value) => /^\**$/.test(value))).toBe(true)
+        }
       })
   })
 


### PR DESCRIPTION
## Motivation

Server-side masking needs every string that might hold customer data to reach the string table, where it can carry a role annotation. `IncrementalSource.Input` is the last V1 record type in the way: it carries form input values outside the string table. This replaces it with the two Change operations added to the schema in #4968.

## Changes

- Form input is recorded as `InputValueChange` (text inputs, `<textarea>`) or `InputSelectionChange` (checkboxes, radio buttons, `<option>`) rather than `IncrementalSource.Input`.
- A radio group's deselections go into a single `InputSelectionChange`, which is what its `[state, ...nodeIds]` shape is for.
- A `<select>` is recorded against the selected `<option>` instead of as a value on the `<select>`.
- `trackInput` no longer assumes it is tracking the main document, allowing us to isolate the tests in iframes, like we do for most newer recorder unit tests.

This is meant to be a change of representation only, so behavior the old code path didn't support is intentionally still unsupported. To clarify the intent, the code involved has been marked with explicit TODOs; we'll build out new features in followup PRs. Improvements which are left for the future include support for `<select multiple>`, indeterminate checkboxes, and more accurate radio group scoping.

**One behavior change worth a look:** a masked `<select>` now records nothing, where before it recorded `'***'` as the select's value. A selection state has no placeholder equivalent; recording one at all would give away which option the user picked. For this reason, a masked `<select>` now behaves like a masked checkbox or radio button.

## Checklist

- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file