### PR TITLE
✨ [RUM-18194] default RUM service to the applicationId

### DIFF
--- a/packages/browser-rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/browser-rum-core/src/boot/preStartRum.spec.ts
@@ -117,6 +117,21 @@ describe('preStartRum', () => {
         expect(strategy.initConfiguration?.sessionSampleRate).toEqual(100)
       })
 
+      it('should default the service to the web application id rather than the bridge placeholder', () => {
+        mockEventBridge()
+        strategy.init({ ...DEFAULT_INIT_CONFIGURATION, applicationId: 'my-web-app-id' }, PUBLIC_API)
+        expect(strategy.initConfiguration?.service).toEqual('my-web-app-id')
+      })
+
+      it('should keep the service provided in the init configuration', () => {
+        mockEventBridge()
+        strategy.init(
+          { ...DEFAULT_INIT_CONFIGURATION, applicationId: 'my-web-app-id', service: 'my-service' },
+          PUBLIC_API
+        )
+        expect(strategy.initConfiguration?.service).toEqual('my-service')
+      })
+
       it('should set the default privacy level received from the bridge if the not provided in the init configuration', () => {
         mockEventBridge({ privacyLevel: DefaultPrivacyLevel.ALLOW })
         const hybridInitConfiguration: Omit<RumInitConfiguration, 'applicationId' | 'clientToken'> = {}

--- a/packages/browser-rum-core/src/boot/preStartRum.ts
+++ b/packages/browser-rum-core/src/boot/preStartRum.ts
@@ -372,6 +372,9 @@ export function createPreStartStrategy(
 function overrideInitConfigurationForBridge(initConfiguration: RumInitConfiguration): RumInitConfiguration {
   return {
     ...initConfiguration,
+    // Resolve the service default here, while the web application id is still available: the
+    // placeholder below would otherwise be used, and it is shared by every bridge session.
+    service: initConfiguration.service || initConfiguration.applicationId,
     applicationId: '00000000-aaaa-0000-aaaa-000000000000',
     clientToken: 'empty',
     sessionSampleRate: 100,

--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -40,6 +40,44 @@ describe('validateAndBuildRumConfiguration', () => {
     })
   })
 
+  describe('service', () => {
+    it('defaults to the applicationId if the option is not provided', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, applicationId: 'my-app-id' })!.service
+      ).toBe('my-app-id')
+    })
+
+    it('is set to the provided value', () => {
+      expect(
+        validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          applicationId: 'my-app-id',
+          service: 'my-service',
+        })!.service
+      ).toBe('my-service')
+    })
+
+    it('defaults to the applicationId if the option is null', () => {
+      expect(
+        validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          applicationId: 'my-app-id',
+          service: null,
+        })!.service
+      ).toBe('my-app-id')
+    })
+
+    it('defaults to the applicationId if the option is an empty string', () => {
+      expect(
+        validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          applicationId: 'my-app-id',
+          service: '',
+        })!.service
+      ).toBe('my-app-id')
+    })
+  })
+
   describe('sessionReplaySampleRate', () => {
     it('defaults to 0 if the option is not provided', () => {
       expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.sessionReplaySampleRate).toBe(0)

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -76,6 +76,17 @@ export interface RumInitConfiguration extends InitConfiguration {
   applicationId: string
 
   /**
+   * The service name for your application. Follows the [tag syntax requirements](https://docs.datadoghq.com/getting_started/tagging/#define-tags).
+   *
+   * When omitted, it defaults to the {@link RumInitConfiguration.applicationId}. Note that
+   * `allowedTracingUrls` still requires an explicitly configured service.
+   *
+   * @category Data Collection
+   * @defaultValue the `applicationId`
+   */
+  service?: string | undefined | null
+
+  /**
    * Whether to propagate user and account IDs in the baggage header of trace requests.
    *
    * @category Tracing
@@ -523,6 +534,9 @@ export function validateAndBuildRumConfiguration(
 
   return {
     ...config,
+    // Fall back to the applicationId so events are always attributed to a service. Applied after
+    // the tracing check above, which still requires an explicitly configured service.
+    service: config.service || config.applicationId,
     sessionReplayCanvasRecording,
     allowedTracingUrls,
     beforeSend: config.beforeSend

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -78,7 +78,6 @@ export interface RumInitConfiguration extends InitConfiguration {
   /**
    * The service name for your application. Follows the [tag syntax requirements](https://docs.datadoghq.com/getting_started/tagging/#define-tags).
    *
-   * When omitted, it defaults to the {@link RumInitConfiguration.applicationId}. Note that
    * `allowedTracingUrls` still requires an explicitly configured service.
    *
    * @category Data Collection
@@ -534,8 +533,6 @@ export function validateAndBuildRumConfiguration(
 
   return {
     ...config,
-    // Fall back to the applicationId so events are always attributed to a service. Applied after
-    // the tracing check above, which still requires an explicitly configured service.
     service: config.service || config.applicationId,
     sessionReplayCanvasRecording,
     allowedTracingUrls,

--- a/packages/browser-rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/browser-rum-core/src/domain/view/trackViews.spec.ts
@@ -306,14 +306,14 @@ describe('view lifecycle', () => {
       expect(getViewCreate(6)).toEqual(
         jasmine.objectContaining({
           name: undefined,
-          service: 'appId',
+          service: 'app-id',
           version: undefined,
         })
       )
       expect(getViewCreate(7)).toEqual(
         jasmine.objectContaining({
           name: undefined,
-          service: 'appId',
+          service: 'app-id',
           version: undefined,
         })
       )
@@ -1049,7 +1049,7 @@ describe('start view', () => {
 
     expect(getViewUpdate(2)).toEqual(
       jasmine.objectContaining({
-        service: 'appId',
+        service: 'app-id',
         version: undefined,
       })
     )
@@ -1073,7 +1073,7 @@ describe('start view', () => {
     startView({ service: null, version: null })
     expect(getViewUpdate(2)).toEqual(
       jasmine.objectContaining({
-        service: 'appId',
+        service: 'app-id',
         version: undefined,
       })
     )

--- a/packages/browser-rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/browser-rum-core/src/domain/view/trackViews.spec.ts
@@ -4,7 +4,7 @@ import { PageExitReason, display } from '@datadog/browser-core'
 
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock, registerCleanupTask, createNewEvent } from '@datadog/browser-core/test'
-import { createPerformanceEntry, mockPerformanceObserver } from '../../../test'
+import { createPerformanceEntry, mockPerformanceObserver, FAKE_APP_ID } from '../../../test'
 import type { AssembledRumEvent } from '../../rawRumEvent.types'
 import { RumEventType, ViewLoadingType } from '../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
@@ -306,14 +306,14 @@ describe('view lifecycle', () => {
       expect(getViewCreate(6)).toEqual(
         jasmine.objectContaining({
           name: undefined,
-          service: undefined,
+          service: FAKE_APP_ID,
           version: undefined,
         })
       )
       expect(getViewCreate(7)).toEqual(
         jasmine.objectContaining({
           name: undefined,
-          service: undefined,
+          service: FAKE_APP_ID,
           version: undefined,
         })
       )
@@ -1049,7 +1049,7 @@ describe('start view', () => {
 
     expect(getViewUpdate(2)).toEqual(
       jasmine.objectContaining({
-        service: undefined,
+        service: FAKE_APP_ID,
         version: undefined,
       })
     )
@@ -1067,13 +1067,13 @@ describe('start view', () => {
     )
   })
 
-  it('should ignore null service/version', () => {
+  it('should fall back to the configured service/version when they are null', () => {
     const { getViewUpdate, startView } = viewTest
 
     startView({ service: null, version: null })
     expect(getViewUpdate(2)).toEqual(
       jasmine.objectContaining({
-        service: undefined,
+        service: FAKE_APP_ID,
         version: undefined,
       })
     )

--- a/packages/browser-rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/browser-rum-core/src/domain/view/trackViews.spec.ts
@@ -4,7 +4,7 @@ import { PageExitReason, display } from '@datadog/browser-core'
 
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock, registerCleanupTask, createNewEvent } from '@datadog/browser-core/test'
-import { createPerformanceEntry, mockPerformanceObserver, FAKE_APP_ID } from '../../../test'
+import { createPerformanceEntry, mockPerformanceObserver } from '../../../test'
 import type { AssembledRumEvent } from '../../rawRumEvent.types'
 import { RumEventType, ViewLoadingType } from '../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
@@ -306,14 +306,14 @@ describe('view lifecycle', () => {
       expect(getViewCreate(6)).toEqual(
         jasmine.objectContaining({
           name: undefined,
-          service: FAKE_APP_ID,
+          service: 'appId',
           version: undefined,
         })
       )
       expect(getViewCreate(7)).toEqual(
         jasmine.objectContaining({
           name: undefined,
-          service: FAKE_APP_ID,
+          service: 'appId',
           version: undefined,
         })
       )
@@ -1049,7 +1049,7 @@ describe('start view', () => {
 
     expect(getViewUpdate(2)).toEqual(
       jasmine.objectContaining({
-        service: FAKE_APP_ID,
+        service: 'appId',
         version: undefined,
       })
     )
@@ -1073,7 +1073,7 @@ describe('start view', () => {
     startView({ service: null, version: null })
     expect(getViewUpdate(2)).toEqual(
       jasmine.objectContaining({
-        service: FAKE_APP_ID,
+        service: 'appId',
         version: undefined,
       })
     )

--- a/packages/browser-rum-core/test/mockRumConfiguration.ts
+++ b/packages/browser-rum-core/test/mockRumConfiguration.ts
@@ -1,9 +1,8 @@
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { validateAndBuildRumConfiguration } from '../src/domain/configuration'
 
-export const FAKE_APP_ID = 'appId'
-
 export function mockRumConfiguration(partialConfig: Partial<RumConfiguration> = {}): RumConfiguration {
+  const FAKE_APP_ID = 'appId'
   const baseConfig: RumConfiguration = {
     ...validateAndBuildRumConfiguration({
       clientToken: 'xxx',

--- a/packages/browser-rum-core/test/mockRumConfiguration.ts
+++ b/packages/browser-rum-core/test/mockRumConfiguration.ts
@@ -1,8 +1,9 @@
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { validateAndBuildRumConfiguration } from '../src/domain/configuration'
 
+export const FAKE_APP_ID = 'appId'
+
 export function mockRumConfiguration(partialConfig: Partial<RumConfiguration> = {}): RumConfiguration {
-  const FAKE_APP_ID = 'appId'
   const baseConfig: RumConfiguration = {
     ...validateAndBuildRumConfiguration({
       clientToken: 'xxx',

--- a/packages/browser-rum-core/test/mockRumConfiguration.ts
+++ b/packages/browser-rum-core/test/mockRumConfiguration.ts
@@ -2,7 +2,7 @@ import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { validateAndBuildRumConfiguration } from '../src/domain/configuration'
 
 export function mockRumConfiguration(partialConfig: Partial<RumConfiguration> = {}): RumConfiguration {
-  const FAKE_APP_ID = 'appId'
+  const FAKE_APP_ID = 'app-id'
   const baseConfig: RumConfiguration = {
     ...validateAndBuildRumConfiguration({
       clientToken: 'xxx',

--- a/packages/browser-rum/src/boot/datadogRecorder.spec.ts
+++ b/packages/browser-rum/src/boot/datadogRecorder.spec.ts
@@ -84,7 +84,7 @@ describe('startRecording', () => {
     expect(requests[0].segment).toEqual(jasmine.any(Object))
     expect(requests[0].event).toEqual({
       application: {
-        id: 'appId',
+        id: 'app-id',
       },
       creation_reason: 'init',
       end: jasmine.stringMatching(/^\d{13}$/),

--- a/test/e2e/scenario/profiling.scenario.ts
+++ b/test/e2e/scenario/profiling.scenario.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
 import { createTest } from '../lib/framework'
 import { generateLongTask } from '../lib/helpers/browser.ts'
+import { APPLICATION_ID } from '../lib/helpers/configuration'
 
 test.describe('profiling', () => {
   test.beforeEach(({ browserName }) => {
@@ -58,7 +59,7 @@ test.describe('profiling', () => {
         runtime: 'chrome',
         format: 'json',
         version: 4,
-        tags_profiler: 'sdk_version:dev,language:javascript,runtime:chrome,family:chrome,host:browser',
+        tags_profiler: `sdk_version:dev,service:${APPLICATION_ID},language:javascript,runtime:chrome,family:chrome,host:browser`,
         _dd: {
           clock_drift: expect.any(Number),
         },


### PR DESCRIPTION
## Motivation

RUM events from apps that never set `service` arrive with no service attribution at all. The mobile SDKs already fall back to something sensible (iOS uses the bundle identifier, Android the manifest application ID), browser was the odd one out.

## Changes

When `service` is not configured, it now falls back to the `applicationId`.

The fallback is applied after the `allowedTracingUrls` check, not before, so tracing still refuses to start without an explicitly configured service. That check would otherwise become unreachable and apps would silently start injecting trace headers pointing at a service name that matches nothing in APM.

Logs is untouched. It has no `applicationId` of its own, and `RumInternalContext` doesn't carry `service`, so nothing leaks across when both SDKs run.

## Test instructions

- Set `applicationId: '0a1b2c3d-4e5f-6789-abcd-ef0123456789'` in `sandbox/index.html` and leave `service` out
- Run `yarn dev` and open http://localhost:8080
- In the console, run `window.__ddBrowserSdkExtensionCallback = (msg) => console.log(msg.payload.type, msg.payload.service, msg.payload.ddtags)`
- Reload and click around
- _Check RUM events have `service: '0a1b2c3d-...'` and `ddtags` contains `service:0a1b2c3d-...`_
- _Check `DD_RUM.getInitConfiguration().service` is still undefined, the default should not leak into the getter_
- Run `DD_LOGS.logger.info('test')`
- _Check the log has no `service` and its `ddtags` is only `sdk_version:dev`_
- Add `allowedTracingUrls: ['http://localhost:8080']` and remove `service`
- _Check init still fails with "Service needs to be configured when tracing is enabled"_

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change. `DEFAULT_RUM_CONFIGURATION` sets no `service`, so `profiling.scenario.ts` now asserts the defaulted value end to end in `tags_profiler`.
- [x] Updated documentation and/or relevant AGENTS.md file
