### PR TITLE
✨ [RUM-18253] attach debug_ids to logs events

### DIFF
--- a/packages/browser-core/src/domain/error/error.ts
+++ b/packages/browser-core/src/domain/error/error.ts
@@ -46,7 +46,7 @@ function computeErrorBase({
   }
 }
 
-function getStackTraceUrls(stackTrace: StackTrace | undefined): string[] {
+export function getStackTraceUrls(stackTrace: StackTrace | undefined): string[] {
   return stackTrace?.stack.map((frame) => frame.url).filter((url): url is string => !!url) ?? []
 }
 

--- a/packages/browser-core/src/domain/report/reportObservable.spec.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.spec.ts
@@ -1,5 +1,10 @@
 import type { MockCspEventListener, MockReportingObserver } from '../../../test'
-import { mockReportingObserver, mockCspEventListener, FAKE_CSP_VIOLATION_EVENT } from '../../../test'
+import {
+  mockReportingObserver,
+  mockCspEventListener,
+  mockSourceCodeContext,
+  FAKE_CSP_VIOLATION_EVENT,
+} from '../../../test'
 import type { Subscription } from '../../tools/observable'
 import { ErrorHandling, ErrorSource } from '../error/error.types'
 import type { RawReportError } from './reportObservable'
@@ -63,7 +68,31 @@ describe('report observable', () => {
   at <anonymous> @ http://foo.bar/index.js:17:8`,
       handling: ErrorHandling.UNHANDLED,
       csp: { disposition: 'enforce' },
+      debugIds: undefined,
     })
+  })
+
+  it('should resolve debug ids from the report source file', () => {
+    const debugId = '01234567-89ab-cdef-0123-456789abcdef'
+    mockSourceCodeContext({ 'Error: foo\n    at foo (http://foo.bar/index.js:52:15)': { ddDebugId: debugId } })
+
+    consoleSubscription = initReportObservable([RawReportType.intervention]).subscribe(notifyReport)
+    reportingObserver.raiseReport(RawReportType.intervention)
+
+    const [report] = notifyReport.calls.mostRecent().args
+
+    expect(report.debugIds).toEqual([{ url: 'http://foo.bar/index.js', id: debugId }])
+  })
+
+  it('should not set debug ids when the report source file has none', () => {
+    mockSourceCodeContext()
+
+    consoleSubscription = initReportObservable([RawReportType.intervention]).subscribe(notifyReport)
+    reportingObserver.raiseReport(RawReportType.intervention)
+
+    const [report] = notifyReport.calls.mostRecent().args
+
+    expect(report.debugIds).toBeUndefined()
   })
 
   it(`should not notify ${RawReportType.cspViolation} when the event is not supported`, () => {

--- a/packages/browser-core/src/domain/report/reportObservable.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.ts
@@ -73,76 +73,55 @@ function createCspViolationReportObservable() {
   })
 }
 
-/**
- * The single frame every report kind boils down to. Reports don't carry a real stack, but they all
- * point at a source file, so this is what both the stack trace and the debug ids are derived from.
- */
-interface ReportSourceLocation {
-  message: string
-  sourceFile: string | null
-  lineNumber: number | null
-  columnNumber: number | null
-}
-
 function buildRawReportErrorFromReport(report: DeprecationReport | InterventionReport): RawReportError {
   const { type, body } = report
 
-  return buildRawReportError(
-    {
-      type: body.id,
-      message: `${type}: ${body.message}`,
-      originalError: report,
-    },
-    {
-      message: body.message,
-      sourceFile: body.sourceFile,
-      lineNumber: body.lineNumber,
-      columnNumber: body.columnNumber,
-    }
-  )
+  return buildRawReportError({
+    type: body.id,
+    message: `${type}: ${body.message}`,
+    originalError: report,
+    stack: buildStack(body.id, body.message, body.sourceFile, body.lineNumber, body.columnNumber),
+    debugIds: body.sourceFile ? buildDebugIdByUrl([body.sourceFile]) : undefined,
+  })
 }
 
 function buildRawReportErrorFromCspViolation(event: SecurityPolicyViolationEvent): RawReportError {
   const message = `'${event.blockedURI}' blocked by '${event.effectiveDirective}' directive`
-  return buildRawReportError(
-    {
-      type: event.effectiveDirective,
-      message: `${RawReportType.cspViolation}: ${message}`,
-      originalError: event,
-      csp: {
-        disposition: event.disposition,
-      },
+  return buildRawReportError({
+    type: event.effectiveDirective,
+    message: `${RawReportType.cspViolation}: ${message}`,
+    originalError: event,
+    csp: {
+      disposition: event.disposition,
     },
-    {
-      message: event.originalPolicy
+    stack: buildStack(
+      event.effectiveDirective,
+      event.originalPolicy
         ? `${message} of the policy "${safeTruncate(event.originalPolicy, 100, '...')}"`
         : 'no policy',
-      sourceFile: event.sourceFile,
-      lineNumber: event.lineNumber,
-      columnNumber: event.columnNumber,
-    }
-  )
+      event.sourceFile,
+      event.lineNumber,
+      event.columnNumber
+    ),
+    debugIds: event.sourceFile ? buildDebugIdByUrl([event.sourceFile]) : undefined,
+  })
 }
 
-function buildRawReportError(
-  partial: Omit<RawReportError, 'startClocks' | 'source' | 'handling' | 'stack' | 'debugIds' | 'type'> & {
-    type: string
-  },
-  location: ReportSourceLocation
-): RawReportError {
+function buildRawReportError(partial: Omit<RawReportError, 'startClocks' | 'source' | 'handling'>): RawReportError {
   return {
     startClocks: clocksNow(),
     source: ErrorSource.REPORT,
     handling: ErrorHandling.UNHANDLED,
     ...partial,
-    stack: buildStack(partial.type, location),
-    debugIds: location.sourceFile ? buildDebugIdByUrl([location.sourceFile]) : undefined,
   }
 }
 
 function buildStack(
   name: string,
-  { message, sourceFile, lineNumber, columnNumber }: ReportSourceLocation
+  message: string,
+  sourceFile: string | null,
+  lineNumber: number | null,
+  columnNumber: number | null
 ): string | undefined {
   return sourceFile
     ? toStackTraceString({

--- a/packages/browser-core/src/domain/report/reportObservable.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.ts
@@ -6,6 +6,7 @@ import { addEventListener, DOM_EVENT, isEventSupported } from '../../browser/add
 import { safeTruncate } from '../../tools/utils/stringUtils'
 import type { RawError } from '../error/error.types'
 import { ErrorHandling, ErrorSource } from '../error/error.types'
+import { buildDebugIdByUrl } from '../sourceCodeContext'
 import type { ReportType, InterventionReport, DeprecationReport } from './browser.types'
 
 export const RawReportType = {
@@ -72,53 +73,76 @@ function createCspViolationReportObservable() {
   })
 }
 
+/**
+ * The single frame every report kind boils down to. Reports don't carry a real stack, but they all
+ * point at a source file, so this is what both the stack trace and the debug ids are derived from.
+ */
+interface ReportSourceLocation {
+  message: string
+  sourceFile: string | null
+  lineNumber: number | null
+  columnNumber: number | null
+}
+
 function buildRawReportErrorFromReport(report: DeprecationReport | InterventionReport): RawReportError {
   const { type, body } = report
 
-  return buildRawReportError({
-    type: body.id,
-    message: `${type}: ${body.message}`,
-    originalError: report,
-    stack: buildStack(body.id, body.message, body.sourceFile, body.lineNumber, body.columnNumber),
-  })
+  return buildRawReportError(
+    {
+      type: body.id,
+      message: `${type}: ${body.message}`,
+      originalError: report,
+    },
+    {
+      message: body.message,
+      sourceFile: body.sourceFile,
+      lineNumber: body.lineNumber,
+      columnNumber: body.columnNumber,
+    }
+  )
 }
 
 function buildRawReportErrorFromCspViolation(event: SecurityPolicyViolationEvent): RawReportError {
   const message = `'${event.blockedURI}' blocked by '${event.effectiveDirective}' directive`
-  return buildRawReportError({
-    type: event.effectiveDirective,
-    message: `${RawReportType.cspViolation}: ${message}`,
-    originalError: event,
-    csp: {
-      disposition: event.disposition,
+  return buildRawReportError(
+    {
+      type: event.effectiveDirective,
+      message: `${RawReportType.cspViolation}: ${message}`,
+      originalError: event,
+      csp: {
+        disposition: event.disposition,
+      },
     },
-    stack: buildStack(
-      event.effectiveDirective,
-      event.originalPolicy
+    {
+      message: event.originalPolicy
         ? `${message} of the policy "${safeTruncate(event.originalPolicy, 100, '...')}"`
         : 'no policy',
-      event.sourceFile,
-      event.lineNumber,
-      event.columnNumber
-    ),
-  })
+      sourceFile: event.sourceFile,
+      lineNumber: event.lineNumber,
+      columnNumber: event.columnNumber,
+    }
+  )
 }
 
-function buildRawReportError(partial: Omit<RawReportError, 'startClocks' | 'source' | 'handling'>): RawReportError {
+function buildRawReportError(
+  partial: Omit<RawReportError, 'startClocks' | 'source' | 'handling' | 'stack' | 'debugIds' | 'type'> & {
+    type: string
+  },
+  location: ReportSourceLocation
+): RawReportError {
   return {
     startClocks: clocksNow(),
     source: ErrorSource.REPORT,
     handling: ErrorHandling.UNHANDLED,
     ...partial,
+    stack: buildStack(partial.type, location),
+    debugIds: location.sourceFile ? buildDebugIdByUrl([location.sourceFile]) : undefined,
   }
 }
 
 function buildStack(
   name: string,
-  message: string,
-  sourceFile: string | null,
-  lineNumber: number | null,
-  columnNumber: number | null
+  { message, sourceFile, lineNumber, columnNumber }: ReportSourceLocation
 ): string | undefined {
   return sourceFile
     ? toStackTraceString({

--- a/packages/browser-core/src/index.ts
+++ b/packages/browser-core/src/index.ts
@@ -93,6 +93,7 @@ export { instrumentMethod, instrumentConstructor, instrumentSetter } from './too
 export {
   computeRawError,
   getFileFromStackTraceString,
+  getStackTraceUrls,
   isError,
   NO_ERROR_STACK_PRESENT_MESSAGE,
 } from './domain/error/error'

--- a/packages/browser-logs/src/boot/startLogs.spec.ts
+++ b/packages/browser-logs/src/boot/startLogs.spec.ts
@@ -113,6 +113,7 @@ describe('logs', () => {
         tab: {
           id: jasmine.any(String),
         },
+        _dd: {},
       })
     })
 

--- a/packages/browser-logs/src/domain/console/consoleCollection.spec.ts
+++ b/packages/browser-logs/src/domain/console/consoleCollection.spec.ts
@@ -69,6 +69,7 @@ describe('console collection', () => {
         status,
         origin: ErrorSource.CONSOLE,
         error: whatever(),
+        _dd: undefined,
       })
 
       expect(rawLogsEvents[0].domainContext).toEqual({
@@ -116,6 +117,24 @@ describe('console collection', () => {
       kind: undefined,
       message: undefined,
     })
+  })
+
+  it('console error should attach debug_ids from the raw error', () => {
+    ;({ stop: stopConsoleCollection } = startConsoleCollection(
+      validateAndBuildLogsConfiguration({ ...initConfiguration, forwardConsoleLogs: ['error'] })!,
+      lifeCycle,
+      bufferedDataObservable
+    ))
+
+    const debugIds = [{ url: 'http://path/to/debug-id.js', id: '01234567-89ab-cdef-0123-456789abcdef' }]
+    notifyConsole({
+      api: ConsoleApiName.error,
+      message: 'foo bar',
+      handlingStack: '',
+      error: makeRawError({ debugIds }),
+    })
+
+    expect(rawLogsEvents[0].rawLogsEvent._dd).toEqual({ debug_ids: debugIds })
   })
 
   it('should use error context as message context', () => {

--- a/packages/browser-logs/src/domain/console/consoleCollection.ts
+++ b/packages/browser-logs/src/domain/console/consoleCollection.ts
@@ -40,6 +40,7 @@ export function startConsoleCollection(
         message: log.message,
         origin: ErrorSource.CONSOLE,
         error: log.error && createErrorFieldFromRawError(log.error),
+        _dd: log.error && { debug_ids: log.error.debugIds },
         status: LogStatusForApi[log.api],
       },
       messageContext: log.error?.context,

--- a/packages/browser-logs/src/domain/logger.spec.ts
+++ b/packages/browser-logs/src/domain/logger.spec.ts
@@ -1,6 +1,5 @@
 import type { ErrorWithCause } from '@datadog/browser-core'
 import { display, ErrorHandling, NO_ERROR_STACK_PRESENT_MESSAGE } from '@datadog/browser-core'
-import { mockSourceCodeContext } from '@datadog/browser-core/test'
 import type { LogsMessage } from './logger'
 import { HandlerType, Logger, STATUSES } from './logger'
 import { StatusType } from './logger/isAuthorized'
@@ -55,7 +54,6 @@ describe('Logger', () => {
             handling: ErrorHandling.HANDLED,
             fingerprint: undefined,
           },
-          _dd: { debug_ids: undefined },
         })
       })
 
@@ -119,7 +117,6 @@ describe('Logger', () => {
             handling: ErrorHandling.HANDLED,
             fingerprint: undefined,
           },
-          _dd: { debug_ids: undefined },
         },
         status: 'error',
       })
@@ -131,18 +128,6 @@ describe('Logger', () => {
       logger.log('message', {}, StatusType.error, error)
 
       expect(getLoggedMessage(0).context!.foo).toBe('bar')
-    })
-
-    it('should attach debug_ids resolved from the source code context', () => {
-      const url = 'http://path/to/debug-id.js'
-      const debugId = '01234567-89ab-cdef-0123-456789abcdef'
-      mockSourceCodeContext({ [`Error: foo\n    at foo (${url}:52:15)`]: { ddDebugId: debugId } })
-
-      const error = new Error('foo')
-      error.stack = `Error: foo\n    at foo (${url}:52:15)`
-      logger.log('message', {}, StatusType.error, error)
-
-      expect(getLoggedMessage(0).context!._dd).toEqual({ debug_ids: [{ url, id: debugId }] })
     })
 
     describe('when using logger.error', () => {
@@ -196,7 +181,6 @@ describe('Logger', () => {
               ],
               fingerprint: undefined,
             },
-            _dd: { debug_ids: undefined },
           },
         })
       })

--- a/packages/browser-logs/src/domain/logger.spec.ts
+++ b/packages/browser-logs/src/domain/logger.spec.ts
@@ -1,5 +1,6 @@
 import type { ErrorWithCause } from '@datadog/browser-core'
 import { display, ErrorHandling, NO_ERROR_STACK_PRESENT_MESSAGE } from '@datadog/browser-core'
+import { mockSourceCodeContext } from '@datadog/browser-core/test'
 import type { LogsMessage } from './logger'
 import { HandlerType, Logger, STATUSES } from './logger'
 import { StatusType } from './logger/isAuthorized'
@@ -54,6 +55,7 @@ describe('Logger', () => {
             handling: ErrorHandling.HANDLED,
             fingerprint: undefined,
           },
+          _dd: { debug_ids: undefined },
         })
       })
 
@@ -117,6 +119,7 @@ describe('Logger', () => {
             handling: ErrorHandling.HANDLED,
             fingerprint: undefined,
           },
+          _dd: { debug_ids: undefined },
         },
         status: 'error',
       })
@@ -128,6 +131,18 @@ describe('Logger', () => {
       logger.log('message', {}, StatusType.error, error)
 
       expect(getLoggedMessage(0).context!.foo).toBe('bar')
+    })
+
+    it('should attach debug_ids resolved from the source code context', () => {
+      const url = 'http://path/to/debug-id.js'
+      const debugId = '01234567-89ab-cdef-0123-456789abcdef'
+      mockSourceCodeContext({ [`Error: foo\n    at foo (${url}:52:15)`]: { ddDebugId: debugId } })
+
+      const error = new Error('foo')
+      error.stack = `Error: foo\n    at foo (${url}:52:15)`
+      logger.log('message', {}, StatusType.error, error)
+
+      expect(getLoggedMessage(0).context!._dd).toEqual({ debug_ids: [{ url, id: debugId }] })
     })
 
     describe('when using logger.error', () => {
@@ -181,6 +196,7 @@ describe('Logger', () => {
               ],
               fingerprint: undefined,
             },
+            _dd: { debug_ids: undefined },
           },
         })
       })

--- a/packages/browser-logs/src/domain/logger.ts
+++ b/packages/browser-logs/src/domain/logger.ts
@@ -78,6 +78,7 @@ export class Logger {
         context = combine(
           {
             error: createErrorFieldFromRawError(rawError, { includeMessage: true }),
+            _dd: { debug_ids: rawError.debugIds },
           },
           rawError.context,
           sanitizedMessageContext

--- a/packages/browser-logs/src/domain/logger.ts
+++ b/packages/browser-logs/src/domain/logger.ts
@@ -1,4 +1,4 @@
-import type { Context, ContextManager } from '@datadog/browser-core'
+import type { Context, ContextManager, DebugIdEntry } from '@datadog/browser-core'
 import { clocksNow } from '@datadog/js-core/time'
 import { combine } from '@datadog/js-core/util'
 import {
@@ -21,6 +21,7 @@ export interface LogsMessage {
   message: string
   status: StatusType
   context?: Context
+  debugIds?: DebugIdEntry[]
 }
 
 export const HandlerType = {
@@ -65,6 +66,7 @@ export class Logger {
     callMonitored(() => {
       const sanitizedMessageContext = sanitize(messageContext) as Context
       let context: Context
+      let debugIds: DebugIdEntry[] | undefined
 
       if (error !== undefined && error !== null) {
         const rawError = computeRawError({
@@ -75,10 +77,11 @@ export class Logger {
           startClocks: clocksNow(),
         })
 
+        debugIds = rawError.debugIds
+
         context = combine(
           {
             error: createErrorFieldFromRawError(rawError, { includeMessage: true }),
-            _dd: { debug_ids: rawError.debugIds },
           },
           rawError.context,
           sanitizedMessageContext
@@ -92,6 +95,7 @@ export class Logger {
           message: sanitize(message)!,
           context,
           status,
+          ...(debugIds ? { debugIds } : {}),
         },
         this,
         handlingStack

--- a/packages/browser-logs/src/domain/logger/loggerCollection.spec.ts
+++ b/packages/browser-logs/src/domain/logger/loggerCollection.spec.ts
@@ -93,6 +93,21 @@ describe('logger collection', () => {
       expect(originalConsoleMethods.warn).not.toHaveBeenCalled()
       expect(originalConsoleMethods.debug).not.toHaveBeenCalled()
     })
+
+    it('does not leak debug ids into the console output', () => {
+      handleLog(
+        {
+          message: 'message',
+          status: StatusType.error,
+          debugIds: [{ url: 'http://path/to/debug-id.js', id: '01234567-89ab-cdef-0123-456789abcdef' }],
+        },
+        logger,
+        HANDLING_STACK,
+        COMMON_CONTEXT
+      )
+
+      expect(originalConsoleMethods.error).toHaveBeenCalledOnceWith('message', {})
+    })
   })
 
   describe('when handle type is set to "http"', () => {
@@ -116,6 +131,7 @@ describe('logger collection', () => {
           origin: ErrorSource.LOGGER,
           message: 'message',
           status: StatusType.error,
+          _dd: { debug_ids: undefined },
         },
         messageContext: {
           foo: 'from-logger',
@@ -146,6 +162,23 @@ describe('logger collection', () => {
       handleLog({ message: 'message', status: 'unknown' as StatusType }, logger, HANDLING_STACK, COMMON_CONTEXT)
 
       expect(rawLogsEvents.length).toBe(0)
+    })
+
+    it('attaches debug ids to the raw log event', () => {
+      handleLog(
+        {
+          message: 'message',
+          status: StatusType.error,
+          debugIds: [{ url: 'http://path/to/debug-id.js', id: '01234567-89ab-cdef-0123-456789abcdef' }],
+        },
+        logger,
+        HANDLING_STACK,
+        COMMON_CONTEXT
+      )
+
+      expect(rawLogsEvents[0].rawLogsEvent._dd).toEqual({
+        debug_ids: [{ url: 'http://path/to/debug-id.js', id: '01234567-89ab-cdef-0123-456789abcdef' }],
+      })
     })
   })
 

--- a/packages/browser-logs/src/domain/logger/loggerCollection.ts
+++ b/packages/browser-logs/src/domain/logger/loggerCollection.ts
@@ -31,6 +31,7 @@ export function startLoggerCollection(lifeCycle: LifeCycle) {
           message: logsMessage.message,
           status: logsMessage.status,
           origin: ErrorSource.LOGGER,
+          _dd: { debug_ids: logsMessage.debugIds },
         },
         messageContext,
         savedCommonContext,

--- a/packages/browser-logs/src/domain/networkError/networkErrorCollection.spec.ts
+++ b/packages/browser-logs/src/domain/networkError/networkErrorCollection.spec.ts
@@ -1,7 +1,7 @@
 import type { BufferedData, FetchResolveContext } from '@datadog/browser-core'
 import { clocksNow } from '@datadog/js-core/time'
 import { BufferedDataType, ErrorSource, Observable } from '@datadog/browser-core'
-import { registerCleanupTask } from '@datadog/browser-core/test'
+import { mockSourceCodeContext, registerCleanupTask } from '@datadog/browser-core/test'
 import type { RawNetworkLogsEvent } from '../../rawLogsEvent.types'
 import type { LogsConfiguration } from '../configuration'
 
@@ -168,6 +168,30 @@ describe('network error collection', () => {
 
       const log = rawLogsEvents[0].rawLogsEvent
       expect(log.error.stack).toBe('Failed to load')
+    })
+
+    it('should attach debug_ids from the fetch rejection stack trace', () => {
+      const debugIdUrl = 'http://path/to/debug-id.js'
+      mockSourceCodeContext({
+        [`Error: Network failure\n    at foo (${debugIdUrl}:1:1)`]: {
+          ddDebugId: '01234567-89ab-cdef-0123-456789abcdef',
+        },
+      })
+
+      const error = new Error('Network failure')
+      error.stack = `Error: Network failure\n    at foo (${debugIdUrl}:1:1)`
+      notifyFetch({ url: 'http://fake-url/', status: 0, error, responseBody: undefined })
+
+      expect(rawLogsEvents[0].rawLogsEvent._dd).toEqual({
+        debug_ids: [{ url: debugIdUrl, id: '01234567-89ab-cdef-0123-456789abcdef' }],
+      })
+    })
+
+    it('should not attach _dd when there are no debug_ids', () => {
+      const error = new Error('Network failure')
+      notifyFetch({ url: 'http://fake-url/', status: 0, error, responseBody: undefined })
+
+      expect(rawLogsEvents[0].rawLogsEvent._dd).toBeUndefined()
     })
   })
 })

--- a/packages/browser-logs/src/domain/networkError/networkErrorCollection.spec.ts
+++ b/packages/browser-logs/src/domain/networkError/networkErrorCollection.spec.ts
@@ -78,6 +78,7 @@ describe('network error collection', () => {
         status_code: 503,
         url: 'http://fake.com/',
       },
+      _dd: { debug_ids: undefined },
     })
   })
 
@@ -185,13 +186,6 @@ describe('network error collection', () => {
       expect(rawLogsEvents[0].rawLogsEvent._dd).toEqual({
         debug_ids: [{ url: debugIdUrl, id: '01234567-89ab-cdef-0123-456789abcdef' }],
       })
-    })
-
-    it('should not attach _dd when there are no debug_ids', () => {
-      const error = new Error('Network failure')
-      notifyFetch({ url: 'http://fake-url/', status: 0, error, responseBody: undefined })
-
-      expect(rawLogsEvents[0].rawLogsEvent._dd).toBeUndefined()
     })
   })
 })

--- a/packages/browser-logs/src/domain/networkError/networkErrorCollection.ts
+++ b/packages/browser-logs/src/domain/networkError/networkErrorCollection.ts
@@ -11,6 +11,8 @@ import {
   ResponseBodyAction,
   safeTruncate,
   ONE_KIBI_BYTE,
+  buildDebugIdByUrl,
+  getStackTraceUrls,
 } from '@datadog/browser-core'
 import { isIntakeUrl } from '@datadog/js-core/transport'
 import type { LogsConfiguration } from '../configuration'
@@ -52,11 +54,9 @@ export function startNetworkErrorCollection(
     if (!isNetworkError(request)) {
       return
     }
-
-    const stack =
-      'error' in request && request.error
-        ? toStackTraceString(computeStackTrace(request.error))
-        : request.responseBody || 'Failed to load'
+    const stackTrace = 'error' in request && request.error ? computeStackTrace(request.error) : undefined
+    const stack = stackTrace ? toStackTraceString(stackTrace) : request.responseBody || 'Failed to load'
+    const debugIds = stackTrace ? buildDebugIdByUrl(getStackTraceUrls(stackTrace)) : undefined
 
     const domainContext: LogsEventDomainContext<typeof ErrorSource.NETWORK> = {
       handlingStack: request.handlingStack,
@@ -71,6 +71,7 @@ export function startNetworkErrorCollection(
           // We don't know if the error was handled or not, so we set it to undefined
           handling: undefined,
         },
+        ...(debugIds ? { _dd: { debug_ids: debugIds } } : {}),
         http: {
           method: request.method as any, // Cast resource method because of case mismatch cf issue RUMF-1152
           status_code: request.status,

--- a/packages/browser-logs/src/domain/networkError/networkErrorCollection.ts
+++ b/packages/browser-logs/src/domain/networkError/networkErrorCollection.ts
@@ -71,7 +71,7 @@ export function startNetworkErrorCollection(
           // We don't know if the error was handled or not, so we set it to undefined
           handling: undefined,
         },
-        ...(debugIds ? { _dd: { debug_ids: debugIds } } : {}),
+        _dd: { debug_ids: debugIds },
         http: {
           method: request.method as any, // Cast resource method because of case mismatch cf issue RUMF-1152
           status_code: request.status,

--- a/packages/browser-logs/src/domain/report/reportCollection.spec.ts
+++ b/packages/browser-logs/src/domain/report/reportCollection.spec.ts
@@ -1,6 +1,6 @@
 import { ErrorHandling, ErrorSource, noop } from '@datadog/browser-core'
 import type { MockReportingObserver } from '@datadog/browser-core/test'
-import { mockReportingObserver } from '@datadog/browser-core/test'
+import { mockReportingObserver, mockSourceCodeContext } from '@datadog/browser-core/test'
 import type { RawReportLogsEvent } from '../../rawLogsEvent.types'
 import { validateAndBuildLogsConfiguration } from '../configuration'
 import type { RawLogsEventCollectedData } from '../lifeCycle'
@@ -49,6 +49,22 @@ describe('reports', () => {
       message: 'intervention: foo bar',
       status: StatusType.error,
       origin: ErrorSource.REPORT,
+      _dd: { debug_ids: undefined },
+    })
+  })
+
+  it('should attach debug_ids resolved from the report source file', () => {
+    const debugId = '01234567-89ab-cdef-0123-456789abcdef'
+    mockSourceCodeContext({ 'Error: foo\n    at foo (http://foo.bar/index.js:52:15)': { ddDebugId: debugId } })
+    ;({ stop: stopReportCollection } = startReportCollection(
+      validateAndBuildLogsConfiguration({ ...initConfiguration, forwardReports: ['intervention'] })!,
+      lifeCycle
+    ))
+
+    reportingObserver.raiseReport('intervention')
+
+    expect(rawLogsEvents[0].rawLogsEvent._dd).toEqual({
+      debug_ids: [{ url: 'http://foo.bar/index.js', id: debugId }],
     })
   })
 
@@ -76,6 +92,7 @@ describe('reports', () => {
       status: StatusType.warn,
       origin: ErrorSource.REPORT,
       error: undefined,
+      _dd: { debug_ids: undefined },
     })
   })
 })

--- a/packages/browser-logs/src/domain/report/reportCollection.ts
+++ b/packages/browser-logs/src/domain/report/reportCollection.ts
@@ -33,6 +33,7 @@ export function startReportCollection(configuration: LogsConfiguration, lifeCycl
         message,
         origin: ErrorSource.REPORT,
         error,
+        _dd: { debug_ids: rawError.debugIds },
         status,
       },
     })

--- a/packages/browser-logs/src/domain/runtimeError/runtimeErrorCollection.spec.ts
+++ b/packages/browser-logs/src/domain/runtimeError/runtimeErrorCollection.spec.ts
@@ -71,6 +71,7 @@ describe('runtime error collection', () => {
         fingerprint: undefined,
         message: undefined,
       },
+      _dd: { debug_ids: undefined },
       message: 'error!',
       status: StatusType.error,
       origin: ErrorSource.SOURCE,
@@ -125,6 +126,7 @@ describe('runtime error collection', () => {
         fingerprint: undefined,
         message: undefined,
       },
+      _dd: { debug_ids: undefined },
       message: 'High level error',
       status: StatusType.error,
       origin: ErrorSource.SOURCE,
@@ -142,6 +144,22 @@ describe('runtime error collection', () => {
     })
 
     expect(rawLogsEvents.length).toEqual(0)
+  })
+
+  it('should attach debug_ids from runtime errors', () => {
+    const { rawLogsEvents, bufferedDataObservable } = startRuntimeErrorCollectionWithDefaults()
+
+    bufferedDataObservable.notify({
+      type: BufferedDataType.RUNTIME_ERROR,
+      data: {
+        ...RAW_ERROR,
+        debugIds: [{ url: 'http://path/to/debug-id.js', id: '01234567-89ab-cdef-0123-456789abcdef' }],
+      },
+    })
+
+    expect(rawLogsEvents[0].rawLogsEvent._dd).toEqual({
+      debug_ids: [{ url: 'http://path/to/debug-id.js', id: '01234567-89ab-cdef-0123-456789abcdef' }],
+    })
   })
 
   it('should retrieve dd_context from runtime errors', () => {

--- a/packages/browser-logs/src/domain/runtimeError/runtimeErrorCollection.ts
+++ b/packages/browser-logs/src/domain/runtimeError/runtimeErrorCollection.ts
@@ -31,6 +31,7 @@ export function startRuntimeErrorCollection(
           message: error.message,
           date: error.startClocks.timeStamp,
           error: createErrorFieldFromRawError(error),
+          _dd: { debug_ids: error.debugIds },
           origin: ErrorSource.SOURCE,
           status: StatusType.error,
         },

--- a/packages/browser-logs/src/logsEvent.types.ts
+++ b/packages/browser-logs/src/logsEvent.types.ts
@@ -160,6 +160,24 @@ export interface LogsEvent {
     name?: string
     [k: string]: unknown
   }
+  /**
+   * Internal properties
+   */
+  _dd?: {
+    /**
+     * Mapping of source file URLs to their debug IDs for source map deobfuscation
+     */
+    debug_ids?: Array<{
+      /**
+       * URL of the source file
+       */
+      url: string
+      /**
+       * Debug ID (UUID) for the source file
+       */
+      id: string
+    }>
+  }
 
   [k: string]: unknown
 }

--- a/packages/browser-logs/src/rawLogsEvent.types.ts
+++ b/packages/browser-logs/src/rawLogsEvent.types.ts
@@ -1,4 +1,4 @@
-import type { ErrorSource, RawErrorCause, ErrorHandling } from '@datadog/browser-core'
+import type { ErrorSource, RawErrorCause, ErrorHandling, DebugIdEntry } from '@datadog/browser-core'
 import type { TimeStamp } from '@datadog/js-core/time'
 import type { StatusType } from './domain/logger/isAuthorized'
 
@@ -19,12 +19,15 @@ interface Error {
   handling: ErrorHandling | undefined
 }
 
-interface CommonRawLogsEvent {
+export interface CommonRawLogsEvent {
   date: TimeStamp
   message: string
   status: StatusType
   error?: Error
   origin: ErrorSource
+  _dd?: {
+    debug_ids?: DebugIdEntry[]
+  }
 }
 
 export interface RawConsoleLogsEvent extends CommonRawLogsEvent {

--- a/packages/browser-rum-core/src/domain/error/trackReportError.spec.ts
+++ b/packages/browser-rum-core/src/domain/error/trackReportError.spec.ts
@@ -46,6 +46,7 @@ describe('trackReportError', () => {
       handling: ErrorHandling.UNHANDLED,
       type: 'NavigatorVibrate',
       originalError: FAKE_REPORT,
+      debugIds: undefined,
     })
   })
 
@@ -64,6 +65,7 @@ describe('trackReportError', () => {
       csp: {
         disposition: FAKE_CSP_VIOLATION_EVENT.disposition,
       },
+      debugIds: undefined,
     })
   })
 })

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -287,7 +287,15 @@ export function microfrontendSetup(options: SetupOptions, servers: Servers) {
     header += setupExtension(options, servers)
   }
 
-  const { rumScriptUrl } = createCrossOriginScriptUrls(servers, options)
+  const { logsScriptUrl, rumScriptUrl } = createCrossOriginScriptUrls(servers, options)
+
+  if (options.logs) {
+    header += html`<script type="text/javascript" src="${logsScriptUrl}" crossorigin></script>`
+    header += html`<script type="text/javascript">
+      DD_LOGS.setGlobalContext(${JSON.stringify(options.context)})
+      ;(${options.logsInit.toString()})(${formatConfiguration(options.logs, servers)})
+    </script>`
+  }
 
   if (options.rum) {
     header += html`<script type="text/javascript" src="${rumScriptUrl}" crossorigin></script>`

--- a/test/e2e/scenario/microfrontend.scenario.ts
+++ b/test/e2e/scenario/microfrontend.scenario.ts
@@ -534,6 +534,68 @@ test.describe('microfrontend', () => {
       })
   })
 
+  test.describe('Logs debug_id attribution', () => {
+    createTest('runtime errors should have debug_id from source code context')
+      .withLogs()
+      .withSetup(microfrontendSetup)
+      .run(async ({ intakeRegistry, flushEvents, page, withBrowserLogs, baseUrl }) => {
+        await page.click('#app1-runtime-error')
+        await page.click('#app2-runtime-error')
+        await flushEvents()
+
+        expect(intakeRegistry.logsEvents).toHaveLength(2)
+
+        // Stacks are browser-dependent and Firefox reports more frames/chunks, adding more debug_ids entries.
+        // We assert the chunk with arrayContaining instead of toEqual to allow those extras.
+
+        // frame 0 -> app1 expose chunk (app1.ts + common.ts).
+        expect(intakeRegistry.logsEvents[0]._dd?.debug_ids).toEqual(
+          expect.arrayContaining([{ url: `${baseUrl}microfrontend/chunks/${APP1_EXPOSE_CHUNK}`, id: APP1_DEBUG_ID }])
+        )
+        // frame 0 -> app2 expose chunk (app2.ts + common.ts)
+        expect(intakeRegistry.logsEvents[1]._dd?.debug_ids).toEqual(
+          expect.arrayContaining([{ url: `${baseUrl}microfrontend/chunks/${APP2_EXPOSE_CHUNK}`, id: APP2_DEBUG_ID }])
+        )
+
+        withBrowserLogs((browserLogs) => {
+          expect(browserLogs).toHaveLength(2)
+        })
+      })
+
+    createTest('errors spanning multiple chunks should have a debug_id for each chunk in the stack')
+      .withLogs()
+      .withSetup(microfrontendSetup)
+      .run(async ({ intakeRegistry, flushEvents, page, withBrowserLogs, baseUrl }) => {
+        await page.click('#app1-nested-error')
+        await page.click('#app2-nested-error')
+        await flushEvents()
+
+        expect(intakeRegistry.logsEvents).toHaveLength(2)
+
+        // Stacks are browser-dependent and Firefox reports more frames/chunks, adding more debug_ids entries.
+        // We assert the chunk with arrayContaining instead of toEqual to allow those extras.
+
+        // frame 0 (throw) -> shared lib chunk (boom), frame 1 (caller) -> app1 expose chunk
+        expect(intakeRegistry.logsEvents[0]._dd?.debug_ids).toEqual(
+          expect.arrayContaining([
+            { url: `${baseUrl}microfrontend/chunks/${LIB_EXPOSE_CHUNK}`, id: LIB_DEBUG_ID },
+            { url: `${baseUrl}microfrontend/chunks/${APP1_EXPOSE_CHUNK}`, id: APP1_DEBUG_ID },
+          ])
+        )
+        // same shared lib debug ID, merged with app2's own chunk
+        expect(intakeRegistry.logsEvents[1]._dd?.debug_ids).toEqual(
+          expect.arrayContaining([
+            { url: `${baseUrl}microfrontend/chunks/${LIB_EXPOSE_CHUNK}`, id: LIB_DEBUG_ID },
+            { url: `${baseUrl}microfrontend/chunks/${APP2_EXPOSE_CHUNK}`, id: APP2_DEBUG_ID },
+          ])
+        )
+
+        withBrowserLogs((browserLogs) => {
+          expect(browserLogs).toHaveLength(2)
+        })
+      })
+  })
+
   test.describe('RUM profiling debug_id attribution', () => {
     test.beforeEach(({ browserName }) => {
       test.skip(browserName !== 'chromium', 'JS Profiling API is only available in Chromium')


### PR DESCRIPTION
## Motivation

Part of the sourcemap unminification project. RUM error / long task / profiler events already carry `_dd.debug_ids`. This does the same for the Logs SDK, so minified stacks collected through `@datadog/browser-logs` can be unminified too.

## Changes

`_dd.debug_ids` is now attached to logs events from: `runtimeErrorCollection`, `consoleCollection`, `reportCollection`, `logger`

## Test instructions

```bash
yarn test:e2e -g "debug_id"
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file