### PR TITLE
👷 [PANA-8797] Bump rum-events-format and regenerate schema types

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "woke": "scripts/cli woke"
   },
   "devDependencies": {
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=131bf26801ca82202df1ef5e0124551cdb656410",
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=c6b13a3e00dd323c48240bacb6d8e7699b4e8b7f",
     "@eslint/js": "10.0.1",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@microsoft/api-extractor": "7.58.12",

--- a/packages/browser-rum-core/src/rumEvent.types.ts
+++ b/packages/browser-rum-core/src/rumEvent.types.ts
@@ -320,6 +320,7 @@ export type RumErrorEvent = CommonProperties &
         | 'macos'
         | 'linux'
         | 'maui'
+        | 'nodejs'
       /**
        * Resource properties of the error
        */

--- a/packages/browser-rum/src/domain/record/encoding/changeDecoder.ts
+++ b/packages/browser-rum/src/domain/record/encoding/changeDecoder.ts
@@ -169,6 +169,10 @@ function decodeChangeRecord(
         break
       }
 
+      case ChangeType.ClearStrings:
+        // This change type exists in the schema, but nothing generates it yet.
+        throw new Error(`Unsupported ChangeType: ${change[0]}`)
+
       default:
         change satisfies never
         throw new Error(`Unsupported ChangeType: ${change[0] as any}`)

--- a/packages/browser-rum/src/types/sessionReplay.ts
+++ b/packages/browser-rum/src/types/sessionReplay.ts
@@ -116,6 +116,7 @@ export type Change =
   | [11, ...AddRoleAnnotatedStringsChange[]]
   | [12, ...InputValueChange[]]
   | [13, ...InputSelectionChange[]]
+  | [14]
 /**
  * Browser-specific. Schema representing the addition of a string to the string table, annotated as belonging to the default string role.
  */

--- a/packages/browser-rum/src/types/sessionReplayConstants.ts
+++ b/packages/browser-rum/src/types/sessionReplayConstants.ts
@@ -44,6 +44,9 @@ export type NodeType = (typeof NodeType)[keyof typeof NodeType]
 // otherwise, it triggers a compile-time error.
 type ChangeTypeId<Id, Data> = [Id, ...Data[]] extends SessionReplay.Change ? Id : never
 
+// DatalessChangeTypeId is ChangeTypeId for changes which carry no data.
+type DatalessChangeTypeId<Id> = [Id] extends SessionReplay.Change ? Id : never
+
 export const ChangeType: {
   AddString: ChangeTypeId<0, SessionReplay.AddStringChange>
   AddNode: ChangeTypeId<1, SessionReplay.AddNodeChange>
@@ -59,6 +62,7 @@ export const ChangeType: {
   AddRoleAnnotatedStrings: ChangeTypeId<11, SessionReplay.AddRoleAnnotatedStringsChange>
   InputValue: ChangeTypeId<12, SessionReplay.InputValueChange>
   InputSelection: ChangeTypeId<13, SessionReplay.InputSelectionChange>
+  ClearStrings: DatalessChangeTypeId<14>
 } = {
   AddString: 0,
   AddNode: 1,
@@ -74,6 +78,7 @@ export const ChangeType: {
   AddRoleAnnotatedStrings: 11,
   InputValue: 12,
   InputSelection: 13,
+  ClearStrings: 14,
 } as const
 
 export type ChangeType = (typeof ChangeType)[keyof typeof ChangeType]

--- a/yarn.lock
+++ b/yarn.lock
@@ -712,10 +712,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/rum-events-format@DataDog/rum-events-format#commit=131bf26801ca82202df1ef5e0124551cdb656410":
+"@datadog/rum-events-format@DataDog/rum-events-format#commit=c6b13a3e00dd323c48240bacb6d8e7699b4e8b7f":
   version: 0.0.0
-  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=131bf26801ca82202df1ef5e0124551cdb656410"
-  checksum: 10c0/3633204c0e3e62e4e5b87245fd2eddd6afeb887adbd309d91790f269d7a40abbc7d16d46aeab81e1eb12a89bd000ec6036df97c2c282b27455d8a889e8661bb2
+  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=c6b13a3e00dd323c48240bacb6d8e7699b4e8b7f"
+  checksum: 10c0/01f36a55946b1d9267cc24dcf1a7eba2faad1666ec22cbf997d5ea6bfd1e2f85d97c42d5628005bfd095fa49950dc5a27ed3b666dda3ed567c4ee5f2aa4af803
   languageName: node
   linkType: hard
 
@@ -6098,7 +6098,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "browser-sdk@workspace:."
   dependencies:
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=131bf26801ca82202df1ef5e0124551cdb656410"
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=c6b13a3e00dd323c48240bacb6d8e7699b4e8b7f"
     "@eslint/js": "npm:10.0.1"
     "@jsdevtools/coverage-istanbul-loader": "npm:3.0.5"
     "@microsoft/api-extractor": "npm:7.58.12"


### PR DESCRIPTION
## Motivation

The `rum-events-format` repo has been updated with a new session replay operation that clears the string table. We need to bump the `rum-events-format` dependency in `browser-sdk` to use it.

## Changes

This PR bumps `rum-events-format` to the latest commit. This brings in the session replay changes I need. An unrelated `source_type` change also comes along for the ride.

To keep things compiling, I had to update the definition of `ChangeType` and add a throwing placeholder in `ChangeDecoder`. The placeholder will get replaced in the following PR, which will implement string table clearing support.

## Test instructions

There's not really much to test for this one.