### PR TITLE
✨ [PANA-8797] Allow session replay to clear its string table

### DIFF
--- a/packages/browser-rum/src/domain/record/encoding/changeDecoder.spec.ts
+++ b/packages/browser-rum/src/domain/record/encoding/changeDecoder.spec.ts
@@ -22,19 +22,67 @@ describe('ChangeDecoder', () => {
     expect(decoded.data).toEqual([[ChangeType.Text, [0, 'Hello World']]])
   })
 
-  it('decodes a role-annotated literal to the string it holds', () => {
-    const decoder = createChangeDecoder()
+  describe('clearing the string table', () => {
+    it('interprets the references that follow a clear against an emptied string table', () => {
+      const decoder = createChangeDecoder()
 
-    const decoded = decoder.decode(
-      changeRecord([ChangeType.Text, [0, createString(StringRole.TextContent, 'Hello World')]])
-    )
+      const decoded = decoder.decode(
+        changeRecord(
+          [ChangeType.AddRoleAnnotatedStrings, [StringRole.TextContent, 'before the clear']],
+          [ChangeType.Text, [0, 0]],
+          [ChangeType.ClearStrings],
+          [ChangeType.AddRoleAnnotatedStrings, [StringRole.TextContent, 'after the clear']],
+          [ChangeType.Text, [1, 0]]
+        )
+      )
 
-    expect(decoded.data).toEqual([[ChangeType.Text, [0, 'Hello World']]])
+      // The clear is dropped along with the definitions, and the id that both changes use
+      // resolves to whichever string the string table held at the time.
+      expect(decoded.data).toEqual([
+        [ChangeType.Text, [0, 'before the clear']],
+        [ChangeType.Text, [1, 'after the clear']],
+      ])
+    })
+
+    it('keeps the string table cleared for the records that follow', () => {
+      const decoder = createChangeDecoder()
+      decoder.decode(
+        changeRecord(
+          [ChangeType.AddRoleAnnotatedStrings, [StringRole.TextContent, 'before the clear']],
+          [ChangeType.ClearStrings]
+        )
+      )
+
+      const decoded = decoder.decode(
+        changeRecord(
+          [ChangeType.AddRoleAnnotatedStrings, [StringRole.TextContent, 'after the clear']],
+          [ChangeType.Text, [0, 0]]
+        )
+      )
+
+      expect(decoded.data).toEqual([[ChangeType.Text, [0, 'after the clear']]])
+    })
+
+    it('throws on a reference to a string that a clear discarded', () => {
+      const decoder = createChangeDecoder()
+
+      expect(() =>
+        decoder.decode(
+          changeRecord(
+            [ChangeType.AddRoleAnnotatedStrings, [StringRole.TextContent, 'discarded']],
+            [ChangeType.ClearStrings],
+            [ChangeType.Text, [0, 0]]
+          )
+        )
+      ).toThrowError(/Reference to unknown string/)
+    })
   })
 
-  describe('obsolete string representations', () => {
+  describe('string representations the encoder does not produce', () => {
     const withAddString = () => changeRecord([ChangeType.AddString, 'Hello World'], [ChangeType.Text, [0, 0]])
     const withUntaggedLiteral = () => changeRecord([ChangeType.Text, [0, 'Hello World']])
+    const withAnnotatedLiteral = () =>
+      changeRecord([ChangeType.Text, [0, createString(StringRole.TextContent, 'Hello World')]])
 
     it('throws on an AddString change by default', () => {
       expect(() => createChangeDecoder().decode(withAddString())).toThrowError(/Obsolete AddString change/)
@@ -42,6 +90,12 @@ describe('ChangeDecoder', () => {
 
     it('throws on an untagged string literal by default', () => {
       expect(() => createChangeDecoder().decode(withUntaggedLiteral())).toThrowError(/Obsolete untagged string literal/)
+    })
+
+    it('throws on a role-annotated string literal by default', () => {
+      expect(() => createChangeDecoder().decode(withAnnotatedLiteral())).toThrowError(
+        /Obsolete string literal outside the string table/
+      )
     })
 
     it('decodes an AddString change when they are allowed', () => {
@@ -55,7 +109,14 @@ describe('ChangeDecoder', () => {
 
       expect(decoder.decode(withUntaggedLiteral()).data).toEqual([[ChangeType.Text, [0, 'Hello World']]])
     })
+
+    it('decodes a role-annotated string literal when they are allowed', () => {
+      const decoder = createChangeDecoder({ allowObsoleteStringRepresentations: true })
+
+      expect(decoder.decode(withAnnotatedLiteral()).data).toEqual([[ChangeType.Text, [0, 'Hello World']]])
+    })
   })
+
   describe('keepRoles', () => {
     it('keeps the role a string was defined in', () => {
       const decoder = createChangeDecoder({ keepRoles: true })
@@ -71,7 +132,7 @@ describe('ChangeDecoder', () => {
     })
 
     it('keeps the role of a literal that carries its own', () => {
-      const decoder = createChangeDecoder({ keepRoles: true })
+      const decoder = createChangeDecoder({ allowObsoleteStringRepresentations: true, keepRoles: true })
       const literal = createString(StringRole.Css, 'color: red')
 
       expect(decoder.decode(changeRecord([ChangeType.Text, [0, literal]])).data).toEqual([

--- a/packages/browser-rum/src/domain/record/encoding/changeDecoder.ts
+++ b/packages/browser-rum/src/domain/record/encoding/changeDecoder.ts
@@ -21,7 +21,7 @@ import { createStringTable } from './stringTable'
 /**
  * ChangeDecoder converts a BrowserChangeRecord, or a stream of BrowserChangeRecords, into
  * a more human-readable form by:
- * - Removing the changes that define string table entries.
+ * - Removing the changes that manage the string table.
  * - Replacing string table references in all other changes with their literal values.
  *
  * This makes it easier to visualize the contents of BrowserChangeRecords or to write test
@@ -39,9 +39,10 @@ export interface ChangeDecoder {
 
 export interface ChangeDecoderOptions {
   /**
-   * If true, accept the string representations that the ChangeEncoder no longer produces:
-   * - AddStringChange (rather than AddRoleAnnotatedStringsChange)
-   * - StringLiteral (rather than RoleAnnotatedStringLiteral)
+   * If true, accept the string representations that the ChangeEncoder does not produce:
+   * - AddStringChange (replaced by AddRoleAnnotatedStringsChange)
+   * - StringLiteral (only string table references are generated)
+   * - RoleAnnotatedStringLiteral (only string table references are generated)
    *
    * When this option is false (the default), ChangeDecoder will throw when it encounters
    * these obsolete string representations.
@@ -111,6 +112,12 @@ function decodeChangeRecord(
         // Deliberately don't include this change in the decoded record.
         break
 
+      case ChangeType.ClearStrings:
+        stringTable.clear()
+
+        // Deliberately don't include this change in the decoded record.
+        break
+
       case ChangeType.AddNode: {
         const decoded: [typeof ChangeType.AddNode, ...AddNodeChange[]] = [ChangeType.AddNode]
         for (let i = 1; i < change.length; i++) {
@@ -168,10 +175,6 @@ function decodeChangeRecord(
         decodedData.push(decoded)
         break
       }
-
-      case ChangeType.ClearStrings:
-        // This change type exists in the schema, but nothing generates it yet.
-        throw new Error(`Unsupported ChangeType: ${change[0]}`)
 
       default:
         change satisfies never

--- a/packages/browser-rum/src/domain/record/encoding/changeEncoder.spec.ts
+++ b/packages/browser-rum/src/domain/record/encoding/changeEncoder.spec.ts
@@ -1,13 +1,13 @@
 import { ChangeType, StringRole } from '../../../types'
 import { createString } from './roles'
-import type { StringId } from './stringIds'
+import type { StringId, StringIds } from './stringIds'
 import { createStringIds, StringIdConstants } from './stringIds'
 import type { ChangeEncoder } from './changeEncoder'
 import { createChangeEncoder } from './changeEncoder'
 
 describe('ChangeEncoder', () => {
   let encoder: ChangeEncoder
-  let stringIds: ReturnType<typeof createStringIds>
+  let stringIds: StringIds
 
   beforeEach(() => {
     stringIds = createStringIds()
@@ -196,16 +196,6 @@ describe('ChangeEncoder', () => {
         [ChangeType.Text, [0, 0 as StringId]],
       ])
     })
-
-    it('keeps the role of a string that did not fit in the string table', () => {
-      Object.defineProperty(stringIds, 'size', { get: () => StringIdConstants.SOFT_MAX_SIZE, configurable: true })
-
-      const annotatedString = createString(StringRole.TextContent, 'new-string')
-      encoder.add(ChangeType.Text, [0, annotatedString])
-      const changes = encoder.flush()
-
-      expect(changes).toEqual([[ChangeType.Text, [0, annotatedString]]])
-    })
   })
 
   describe('optimizing the encoding', () => {
@@ -241,51 +231,137 @@ describe('ChangeEncoder', () => {
   })
 
   describe('soft max size of the string table', () => {
-    // Simulates a full string table without actually inserting a million entries.
-    const simulateFullStringTable = () => {
-      Object.defineProperty(stringIds, 'size', { get: () => StringIdConstants.SOFT_MAX_SIZE, configurable: true })
+    /**
+     * Replaces the string table with one that claims to already hold all but
+     * `remainingEntries` of the entries its soft max size allows; inserting enough
+     * strings to actually reach the limit would be far too expensive for a test. The
+     * phantom entries don't affect the ids that real strings get, which still start at
+     * the first id, and clearing the table discards them along with the real entries.
+     */
+    const fillStringTableToWithin = (remainingEntries: number) => {
+      const realStringIds = createStringIds()
+      let phantomStringCount = Number(StringIdConstants.SOFT_MAX_SIZE) - remainingEntries
+      stringIds = {
+        clear: () => {
+          phantomStringCount = 0
+          realStringIds.clear()
+        },
+        get: realStringIds.get,
+        getOrInsert: realStringIds.getOrInsert,
+        get size() {
+          return phantomStringCount + realStringIds.size
+        },
+      }
+      encoder = createChangeEncoder(stringIds)
     }
 
-    it('does not add new strings to the table once the soft max size is reached', () => {
-      simulateFullStringTable()
+    it('clears the string table once the soft max size is reached', () => {
+      fillStringTableToWithin(1)
 
       encoder.add(ChangeType.Text, [0, 'new-string'])
       const changes = encoder.flush()
 
-      // The new string remains a literal in the change data and no definition is emitted. It is
-      // tagged with the role it would have been defined in, even though that role is the
-      // default one, so that the intake can tell what kind of data every literal holds.
-      expect(changes).toEqual([[ChangeType.Text, [0, createString(StringRole.Default, 'new-string')]]])
-    })
-
-    it('still reuses existing string ids once the soft max size is reached', () => {
-      // Put 'existing' in the string table before it fills up.
-      encoder.add(ChangeType.Text, [0, 'existing'])
-      encoder.flush()
-      simulateFullStringTable()
-
-      encoder.add(ChangeType.Text, [0, 'existing'])
-      const changes = encoder.flush()
-
-      // No definition is emitted, but the existing string is still replaced with its id.
-      expect(changes).toEqual([[ChangeType.Text, [0, 0 as StringId]]])
-    })
-
-    it('handles a mix of new and existing strings once the soft max size is reached', () => {
-      // Put 'foo' in the string table before it fills up.
-      encoder.add(ChangeType.AddNode, [null, 'foo'])
-      encoder.flush()
-      simulateFullStringTable()
-
-      encoder.add(ChangeType.AddNode, [null, 'foo', ['class', 'bar']])
-      const changes = encoder.flush()
-
-      // 'foo' is replaced with its existing id; 'class' and 'bar' stay as role-annotated literals.
+      // The new string is defined in the string table like any other. The table is cleared
+      // afterwards, once the changes that refer to its entries have been played back.
       expect(changes).toEqual([
-        [
-          ChangeType.AddNode,
-          [null, 0 as StringId, [createString(StringRole.Default, 'class'), createString(StringRole.Default, 'bar')]],
-        ],
+        [ChangeType.AddRoleAnnotatedStrings, [StringRole.Default, 'new-string']],
+        [ChangeType.Text, [0, 0 as StringId]],
+        [ChangeType.ClearStrings],
+      ])
+    })
+
+    it('keeps the string table until the soft max size is reached', () => {
+      fillStringTableToWithin(2)
+
+      encoder.add(ChangeType.Text, [0, 'new-string'])
+      const changes = encoder.flush()
+
+      expect(changes).toEqual([
+        [ChangeType.AddRoleAnnotatedStrings, [StringRole.Default, 'new-string']],
+        [ChangeType.Text, [0, 0 as StringId]],
+      ])
+    })
+
+    it('counts the strings the buffered changes will define toward the soft max size', () => {
+      fillStringTableToWithin(2)
+
+      // Neither change fills the string table on its own, but together they reach the limit.
+      encoder.add(ChangeType.Text, [0, 'first'])
+      encoder.add(ChangeType.Text, [1, 'second'])
+      const changes = encoder.flush()
+
+      expect(changes).toEqual([
+        [ChangeType.AddRoleAnnotatedStrings, [StringRole.Default, 'first', 'second']],
+        [ChangeType.Text, [0, 0 as StringId], [1, 1 as StringId]],
+        [ChangeType.ClearStrings],
+      ])
+    })
+
+    it('counts a string the changes refer to repeatedly only once', () => {
+      fillStringTableToWithin(2)
+
+      // Both changes refer to the same string, so only one entry is needed for them.
+      encoder.add(ChangeType.Text, [0, 'repeated'])
+      encoder.add(ChangeType.Text, [1, 'repeated'])
+      const changes = encoder.flush()
+
+      expect(changes).toEqual([
+        [ChangeType.AddRoleAnnotatedStrings, [StringRole.Default, 'repeated']],
+        [ChangeType.Text, [0, 0 as StringId], [1, 0 as StringId]],
+      ])
+    })
+
+    it('starts a new run of changes where it clears the string table', () => {
+      fillStringTableToWithin(1)
+
+      // The first change reaches the soft max size, so it ends up in a run of its own, ahead of
+      // the clear. The changes after it define their strings in the emptied table, which hands
+      // out its ids from the start again, rather than carrying them as literals.
+      encoder.add(ChangeType.Text, [0, 'before the clear'])
+      encoder.add(ChangeType.AddNode, [null, 'div', ['class', 'container']])
+      const changes = encoder.flush()
+
+      expect(changes).toEqual([
+        [ChangeType.AddRoleAnnotatedStrings, [StringRole.Default, 'before the clear']],
+        [ChangeType.Text, [0, 0 as StringId]],
+        [ChangeType.ClearStrings],
+        [ChangeType.AddRoleAnnotatedStrings, [StringRole.Default, 'div', 'class', 'container']],
+        [ChangeType.AddNode, [null, 0 as StringId, [1 as StringId, 2 as StringId]]],
+      ])
+    })
+
+    it('keeps a change that depends on an earlier one after it across a clear', () => {
+      fillStringTableToWithin(1)
+
+      // Adding the node reaches the soft max size, so the attribute change that depends on it
+      // lands in the run after the clear. Only the changes within a run are reordered to
+      // satisfy their dependencies, so the node has to stay in the earlier run.
+      encoder.add(ChangeType.AddNode, [null, 'div'])
+      encoder.add(ChangeType.Attribute, [0, ['class', 'container']])
+      const changes = encoder.flush()
+
+      expect(changes).toEqual([
+        [ChangeType.AddRoleAnnotatedStrings, [StringRole.Default, 'div']],
+        [ChangeType.AddNode, [null, 0 as StringId]],
+        [ChangeType.ClearStrings],
+        [ChangeType.AddRoleAnnotatedStrings, [StringRole.Default, 'class', 'container']],
+        [ChangeType.Attribute, [0, [0 as StringId, 1 as StringId]]],
+      ])
+    })
+
+    it('defines strings again once the string table has been cleared', () => {
+      fillStringTableToWithin(1)
+      encoder.add(ChangeType.Text, [0, 'discarded'])
+      encoder.flush()
+
+      encoder.add(ChangeType.Text, [1, 'discarded'])
+      const changes = encoder.flush()
+
+      // The cleared table no longer holds the string, so it is defined again, and it takes the
+      // first id now that the table is empty.
+      expect(changes).toEqual([
+        [ChangeType.AddRoleAnnotatedStrings, [StringRole.Default, 'discarded']],
+        [ChangeType.Text, [1, 0 as StringId]],
       ])
     })
   })

--- a/packages/browser-rum/src/domain/record/encoding/changeEncoder.ts
+++ b/packages/browser-rum/src/domain/record/encoding/changeEncoder.ts
@@ -7,12 +7,92 @@ import type { StringId, StringIds } from './stringIds'
 type ChangeData<T extends ChangeType> =
   Extract<Change, [T, ...unknown[]]> extends [T, ...infer Rest] ? Rest[number] : never
 
+type StringTableChangeTypes =
+  typeof ChangeType.AddString | typeof ChangeType.AddRoleAnnotatedStrings | typeof ChangeType.ClearStrings
+
 /**
  * The change operations a caller can add. Callers are not allowed to generate change
  * operations that manipulate the string table; that's the exclusive responsibility of the
  * encoder.
  */
-type EncodableChangeType = Exclude<ChangeType, typeof ChangeType.AddString | typeof ChangeType.AddRoleAnnotatedStrings>
+type EncodableChangeType = Exclude<ChangeType, StringTableChangeTypes>
+
+/**
+ * ChangeEncoder handles the low-level work of building compact, optimized sequences of
+ * Changes. In particular, it:
+ * - Converts literal strings to string table references, to eliminate the duplication
+ * of transferring the same strings repeatedly.
+ * - Groups the strings it defines by role to minimize the cost of transmitting role information.
+ * - Sorts the busiest string groups first, so that the strings which are referenced most
+ * frequently tend to get ids which have fewer digits and are thus cheaper to reference.
+ * - Groups changes by type, instead of transmitting them strictly in order, so that we
+ * can avoid transmitting a separate Change data structure with an independent type tag
+ * for each small mutation. (It's safe to do this for changes that occur within the same
+ * SerializationTransaction since they logically happen at the same time.)
+ * - Clears the string table when it reaches its soft maximum size, so that there is always
+ * room for the strings the encoder needs to define. Strings are therefore never transmitted
+ * outside of the string table.
+ */
+export interface ChangeEncoder {
+  /**
+   * Encode a Change of the given type and add it to the internal buffer.
+   *
+   * The encoder takes ownership of `data`; the caller must not modify it after adding it.
+   */
+  add<T extends EncodableChangeType>(type: T, data: ChangeData<T>): void
+
+  /** Flush the internal buffer, returning all Changes added since the last flush(). */
+  flush(): Change[]
+}
+
+export function createChangeEncoder(stringIds: StringIds): ChangeEncoder {
+  // Changes are encoded in runs. A run ends when the string table reaches its maximum
+  // size and is cleared; the changes in each run thus always share a single string id
+  // namespace. The currently-active run ends when the caller flushes the encoder.
+
+  // The changes of the runs that have already ended, waiting for the caller to flush them.
+  let flushedChanges: Change[] = []
+
+  // The run that the changes being added now belong to.
+  let run = createRunChangeEncoder(stringIds)
+
+  // Ends the current run, appending the changes it encoded to those of the runs before it,
+  // and starts a new one.
+  const endRun = (): void => {
+    run.flushInto(flushedChanges)
+    run = createRunChangeEncoder(stringIds)
+  }
+
+  // Clears the string table. This has the effect of creating a new string id namespace, so
+  // we also need to end the current run to ensure that the changes we've generated so far
+  // play back in the context of the previous namespace.
+  const clearStringTable = (): void => {
+    endRun()
+    flushedChanges.push([ChangeType.ClearStrings])
+    stringIds.clear()
+  }
+
+  const add = <T extends EncodableChangeType>(type: T, data: ChangeData<T>): void => {
+    run.add(type, data)
+
+    // If this change pushed the string table past its soft maximum size, we need to clear
+    // the string table.
+    if (stringIds.size + run.pendingStringCount >= Number(StringIdConstants.SOFT_MAX_SIZE)) {
+      clearStringTable()
+    }
+  }
+
+  const flush = (): Change[] => {
+    endRun()
+
+    const changes = flushedChanges
+    flushedChanges = []
+
+    return changes
+  }
+
+  return { add, flush }
+}
 
 type StringTableUpdates = [typeof ChangeType.AddRoleAnnotatedStrings, ...AddRoleAnnotatedStringsChange[]]
 
@@ -35,44 +115,44 @@ interface PendingStringGroup {
 }
 
 /**
- * ChangeEncoder handles the low-level work of building compact, optimized sequences of
- * Changes. In particular, it:
- * - Converts literal strings to string table references, to eliminate the duplication
- * of transferring the same strings repeatedly.
- * - Groups the strings it defines by role to minimize the cost of transmitting role information.
- * - Sorts the busiest string groups first, so that the strings which are referenced most
- * frequently tend to get ids which have fewer digits and are thus cheaper to reference.
- * - Groups changes by type, instead of transmitting them strictly in order, so that we
- * can avoid transmitting a separate Change data structure with an independent type tag
- * for each small mutation. (It's safe to do this for changes that occur within the same
- * SerializationTransaction since they logically happen at the same time.)
+ * RunChangeEncoder encodes the changes of a single run for ChangeEncoder. Changes within
+ * a run are grouped together to optimize their representation, and they share a common
+ * string id namespace.
  */
-export interface ChangeEncoder {
+interface RunChangeEncoder {
   /**
-   * Encode a Change of the given type and add it to the internal buffer. Changes that define
-   * string table entries are the encoder's own to emit, so they can't be added here.
+   * Encode a Change of the given type and add it to the run.
    *
-   * The encoder takes ownership of `data`: it isn't finished with it until flush(), which is
-   * when the strings it contains get their ids, so the caller must not modify it after adding it.
+   * The run takes ownership of `data`; the caller must not modify it after adding it.
    */
   add<T extends EncodableChangeType>(type: T, data: ChangeData<T>): void
 
-  /** Flush the internal buffer, returning all Changes added since the last flush(). */
-  flush(): Change[]
+  /**
+   * End the run, appending the Changes it encoded to the given output array. The run must
+   * not be used again afterwards.
+   */
+  flushInto(output: Change[]): void
+
+  /** The number of strings the run will add to the string table when it ends. */
+  get pendingStringCount(): number
 }
 
-export function createChangeEncoder(stringIds: StringIds): ChangeEncoder {
-  let pendingChanges: Partial<Record<ChangeType, unknown[]>> = {}
+function createRunChangeEncoder(stringIds: StringIds): RunChangeEncoder {
+  // The changes added during this run, grouped by type.
+  const pendingChanges: Partial<Record<ChangeType, unknown[]>> = {}
 
-  // Every string in the changes added since the last flush() that isn't in the string table yet,
+  // Every string in the changes added during this run which isn't in the string table yet,
   // grouped by role.
-  let pendingGroups = new Map<StringRole, PendingStringGroup>()
+  const pendingGroups = new Map<StringRole, PendingStringGroup>()
 
-  // The changes added since the last flush() that hold a string with no id yet, and so need a
-  // second pass once flush() has handed out the ids. Tracking them minimizes the amount
+  // The changes added during this run that hold a string with no id yet, and so need a
+  // second pass once the run has handed out the ids. Tracking them minimizes the amount
   // of work the second pass has to do; many changes, especially after the full snapshot,
   // don't introduce any new strings and hence don't require a second pass.
-  let unresolvedChanges: unknown[][] = []
+  const unresolvedChanges: unknown[][] = []
+
+  // How many strings pendingGroups holds.
+  let pendingStringCount = 0
 
   // Set while a change is being encoded if any of its strings has no id yet.
   let changeHasPendingStrings = false
@@ -81,7 +161,7 @@ export function createChangeEncoder(stringIds: StringIds): ChangeEncoder {
   // is already in the string table, and a PendingString when it isn't. The ids depend on
   // how the strings are grouped and on how often each of them is referenced, so we can't
   // greedily assign ids for new strings as soon as we encounter them; we need to wait for
-  // flush().
+  // the run to end.
   const referenceString = (literal: RoleAnnotatedStringLiteral): StringId | PendingString => {
     const id = stringIds.get(literal)
     if (id !== undefined) {
@@ -104,6 +184,7 @@ export function createChangeEncoder(stringIds: StringIds): ChangeEncoder {
 
     const pendingString: PendingString = { literal, id: undefined }
     group.strings.set(literal.string, pendingString)
+    pendingStringCount++
     return pendingString
   }
 
@@ -138,24 +219,20 @@ export function createChangeEncoder(stringIds: StringIds): ChangeEncoder {
     for (const group of Array.from(pendingGroups.values()).sort(byDescendingReferences)) {
       const update: AddRoleAnnotatedStringsChange = [group.role]
       for (const pendingString of group.strings.values()) {
-        if (stringIds.size >= Number(StringIdConstants.SOFT_MAX_SIZE)) {
-          break // The string table is full; the remaining strings stay literals.
-        }
         pendingString.id = stringIds.getOrInsert(pendingString.literal)
         update.push(pendingString.literal.string)
       }
-      if (update.length > 1) {
-        stringTableUpdates.push(update)
-      }
+      stringTableUpdates.push(update)
     }
 
-    return stringTableUpdates.length > 1 ? stringTableUpdates : undefined
+    return stringTableUpdates
   }
 
   const add = <T extends EncodableChangeType>(type: T, data: ChangeData<T>): void => {
     if (!(type in pendingChanges)) {
       pendingChanges[type] = [type]
     }
+
     // Not every kind of change data is an array; a RemoveNode change is a bare node id.
     if (Array.isArray(data)) {
       changeHasPendingStrings = false
@@ -164,20 +241,18 @@ export function createChangeEncoder(stringIds: StringIds): ChangeEncoder {
         unresolvedChanges.push(data)
       }
     }
+
     pendingChanges[type]!.push(data)
   }
 
-  const flush = (): Change[] => {
-    const changes: Change[] = []
-
+  const flushInto = (output: Change[]): void => {
     // String table updates have to come before any change that refers to them.
     const stringTableUpdates = generateStringTableUpdates()
     if (stringTableUpdates) {
-      changes.push(stringTableUpdates)
+      output.push(stringTableUpdates)
     }
 
-    // All strings now either have ids assigned or (in the rare edge case of string table
-    // overflow) are confirmed to not be receiving an id. We can now resolve pending strings.
+    // Every string has an id assigned now, so we can resolve the pending strings.
     for (const change of unresolvedChanges) {
       resolvePendingStrings(change)
     }
@@ -187,6 +262,11 @@ export function createChangeEncoder(stringIds: StringIds): ChangeEncoder {
     // exist between two kinds of change, then the dependent change must come after the
     // change it depends on. This list defines an ordering that ensures that these
     // dependencies are always satisfied.
+    //
+    // Only the changes of this run need to be ordered this way. Callers add changes in an
+    // order that already satisfies their dependencies, so a change can only depend on one
+    // that was added before it, which is one in this run or in a run that already ended;
+    // it's grouping the changes by type that reorders them, and that happens within a run.
     ;[
       ChangeType.AddNode,
       ChangeType.RemoveNode,
@@ -203,23 +283,23 @@ export function createChangeEncoder(stringIds: StringIds): ChangeEncoder {
     ].forEach((changeType: ChangeType): void => {
       const change = pendingChanges[changeType]
       if (change) {
-        changes.push(change as Change)
+        output.push(change as Change)
       }
     })
-
-    pendingChanges = {}
-    pendingGroups = new Map()
-    unresolvedChanges = []
-
-    return changes
   }
 
-  return { add, flush }
+  return {
+    add,
+    flushInto,
+    get pendingStringCount(): number {
+      return pendingStringCount
+    },
+  }
 }
 
 /**
- * Replaces every string in the given change with its assigned id. A string that didn't
- * fit in the string table stays a literal.
+ * Replaces every string in the given change with the id it was assigned. A run gives every
+ * pending string an id before it resolves anything, so by this point they all have one.
  */
 function resolvePendingStrings(array: any[]): void {
   for (let index = 0, length = array.length; index < length; index++) {
@@ -227,7 +307,7 @@ function resolvePendingStrings(array: any[]): void {
     if (Array.isArray(item)) {
       resolvePendingStrings(item)
     } else if (isPendingString(item)) {
-      array[index] = item.id ?? item.literal
+      array[index] = item.id
     }
   }
 }

--- a/packages/browser-rum/src/domain/record/encoding/stringTable.ts
+++ b/packages/browser-rum/src/domain/record/encoding/stringTable.ts
@@ -6,6 +6,9 @@ import type { StringId } from './stringIds'
 export interface StringTable {
   add(newString: string, role: StringRole): void
 
+  /** Remove every string from the table, so that the next string added gets the first id. */
+  clear(): void
+
   /** The string that the given value holds, whichever form it takes. */
   decode(value: StringOrStringReference): string
 
@@ -32,7 +35,12 @@ export function createStringTable(allowObsoleteStringRepresentations = false, ke
     }
 
     if (typeof value === 'object') {
-      return value // A role-annotated string literal.
+      // A role-annotated string literal. The encoder gives every string an entry in the
+      // string table, so something must have built this change data outside the encoder.
+      if (!allowObsoleteStringRepresentations) {
+        throw new Error(`Obsolete string literal outside the string table: ${value.string}`)
+      }
+      return value
     }
 
     const referencedString = strings.get(value as StringId)
@@ -45,6 +53,9 @@ export function createStringTable(allowObsoleteStringRepresentations = false, ke
   return {
     add(newString: string, role: StringRole): void {
       strings.set(strings.size as StringId, createString(role, newString))
+    },
+    clear(): void {
+      strings.clear()
     },
     decode(value: StringOrStringReference): string {
       return literalOf(value).string


### PR DESCRIPTION
## Motivation

Session replay recordings extract strings into a string table, and #4983 annotated each entry with the role its string plays on the page so that the backend can mask sensitive content after the fact. Ideally, we could perform that masking based only on the role-annotated string table, but today that would be insufficient, because the string table isn't the only place sensitive strings could appear. The problem is that when the string table reaches its size limit, we stop adding strings to it and start representing them directly inside the replay operations as literal arguments.

To eliminate this problem, we should handle string table overflow in a different way: we should simply clear the string table when it gets too large.

## Changes

When the string table reaches its soft maximum size, `ChangeEncoder` now clears it. After encoding each change, it compares the table's size against the soft max, and clears the table as soon as the limit is reached. The new `ClearStrings` operation expresses the fact that the string table was cleared in the recording, so that the recorder's encoder and the player's decoder continue to agree on the meaning of string table references.

With this change in place, strings are always transmitted through the string table, and the code that turned them into literals is gone:

- **`changeEncoder.ts`**:  the size check and the clear. Clearing the table ends the current *run*: the changes buffered so far are encoded ahead of the `ClearStrings`, and the changes that follow start from an empty table. `resolvePendingStrings()` no longer falls back to a literal.
- **`changeEncoder.ts`** also gained a new module-private `RunChangeEncoder` helper. This helper owns everything that happens within a run, leaving `ChangeEncoder` to own only cross-run state. `RunChangeEncoder` is single-use, which made it possible to eliminate `ChangeEncoder`'s reset logic.
- **`changeDecoder.ts` / `stringTable.ts`**: the decoder infrastructure (which is only used in tests) now implements `ClearStrings`, replacing the throwing placeholder from the schema PR. `ChangeDecoder` also now rejects a string literal in change data (though there's an opt-out for testing purposes). This makes the whole unit and e2e suite enforce that the SDK never puts a string anywhere but the string table.

## Checklist

- [x] Tested locally
- [ ] Tested on staging (I'll push it immediately after pushing the PR.)
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file.