### PR TITLE
🐛 [PANA-8819] Don't send segments with sendBeacon unless the page is really exiting

### DIFF
--- a/packages/browser-rum/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/browser-rum/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -158,9 +158,10 @@ describe('startSegmentCollection', () => {
         lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, PageExitReason.HIDDEN)
       }
 
-      it('uses `httpRequest.sendOnExit` when sending the segment', () => {
+      it('uses `httpRequest.send` when sending the segment', () => {
         addRecordAndFlushSegment(emulatePageHidden)
-        expect(httpRequestSpy.sendOnExit).toHaveBeenCalled()
+        expect(httpRequestSpy.send).toHaveBeenCalled()
+        expect(httpRequestSpy.sendOnExit).not.toHaveBeenCalled()
       })
 
       it('next segment is created because of visibility hidden event', async () => {

--- a/packages/browser-rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/browser-rum/src/domain/segmentCollection/segmentCollection.ts
@@ -1,6 +1,6 @@
 import type { DeflateEncoder, HttpRequest, TimeoutId, SessionManager } from '@datadog/browser-core'
 import { ONE_SECOND } from '@datadog/js-core/time'
-import { isPageExitReason, clearTimeout, setTimeout } from '@datadog/browser-core'
+import { isPageExitReason, PageExitReason, clearTimeout, setTimeout } from '@datadog/browser-core'
 import type { LifeCycle, ViewHistory, RumConfiguration } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import type { BrowserRecord, CreationReason, SegmentContext } from '../../types'
@@ -110,7 +110,11 @@ export function doStartSegmentCollection(
       state.segment.flush((metadata, stats, encoderResult) => {
         const payload = buildReplayPayload(encoderResult.output, metadata, stats, encoderResult.rawBytesCount)
 
-        if (isPageExitReason(flushReason)) {
+        // sendOnExit() is less reliable than send() since it doesn't retry. If the page is
+        // *really* about to close, sendOnExit() is still better, since it uses a mechanism
+        // that outlives the page itself; for PageExitReason.HIDDEN, though, the page is
+        // probably not actually closing, so we prefer send().
+        if (isPageExitReason(flushReason) && flushReason !== PageExitReason.HIDDEN) {
           httpRequest.sendOnExit(payload)
         } else {
           httpRequest.send(payload)


### PR DESCRIPTION
## Motivation

I saw a corrupt recording recently in which a segment was lost when the page was hidden.  (i.e., it transitioned to `visibilityState: hidden` due to e.g. being backgrounded.) This was the only segment in the whole recording that was lost; all of the other segments were fine. So, what might have caused this?

When the page becomes hidden, the core SDK dispatches a `PREPARE_URGENT_FLUSH` event. The segment collection logic reacts to this by flushing the segment it's currently building and sending it to the intake using `HttpRequest#sendOnExit()`. Under the hood, this invokes the standard `sendBeacon()` API, with a fallback to `fetch()` if the request is too large.

If the page was _really_ exiting, this would be the right thing to do; the normal `HttpRequest#send()` path uses only `fetch()`, and `fetch()` requests are not guaranteed to survive page exit. However, there's a tradeoff for using `HttpRequest#sendOnExit()`: the request does not get retried if it fails. That makes sense; the page is about to close, and all JavaScript will stop running, so there'd be nobody around to perform the retry.

When the page is hidden, it _might_ close immediately afterward, but it often won't, especially on non-mobile platforms. In that situation, the tradeoff is wrong; `HttpRequest#send()` is better, because the retry logic provides more reliable delivery. This difference in reliability is quite possibly what led to the lost segment I observed in that corrupt recording.

The downside of sending the current segment `HttpRequest#send()` when the page is hidden is that delivery would be less reliable compared to `sendOnExit()` if the page _is_ immediately closed. However, that increased reliability only helps us in a limited set of circumstances. The reason is that we only gain that increased reliability for the _current_ segment; `sendOnExit()` skips the queue and sends immediately. Previously segments which might already be enqueued are not "upgraded" to `sendOnExit()`, and are likely to be lost if the page is closing. Since a missing segment breaks all segments that follow, reliably delivering _only_ the current segment isn't that useful. In other words, using `sendOnExit()` is really only beneficial if:
1. The page really does exit immediately.
2. No segments were already enqueued.

Since `sendOnExit()`'s benefits only apply in limited circumstances that we can't reliably predict, we're probably better off sending the current segment using `HttpRequest#send()` when the page is hidden and benefitting from its queuing and retrying capabilities.

## Changes

When the segment collection logic receives `PREPARE_URGENT_FLUSH`, and the reason is `PageExitReason.HIDDEN`, we now send the current segment via `HttpRequest#send()` instead of `HttpRequest#sendOnExit()`.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
