### PR TITLE
📝 Remove beta note from Vue, Angular and Nuxt readme's

### DIFF
--- a/packages/browser-rum-angular/README.md
+++ b/packages/browser-rum-angular/README.md
@@ -1,7 +1,5 @@
 # RUM Browser Monitoring - Angular integration
 
-> **Note**: This integration is in beta. Features and configuration may change.
-
 ## Overview
 
 With the Datadog RUM Angular integration, resolve performance issues quickly in Angular applications by:

--- a/packages/browser-rum-nuxt/README.md
+++ b/packages/browser-rum-nuxt/README.md
@@ -1,7 +1,5 @@
 # RUM Browser Monitoring - Nuxt integration
 
-**Note**: This integration is in Preview. Features and configuration are subject to change.
-
 ## Overview
 
 The Datadog RUM Nuxt integration provides framework-specific instrumentation to help you monitor and debug Nuxt applications. This integration adds:

--- a/packages/browser-rum-vue/README.md
+++ b/packages/browser-rum-vue/README.md
@@ -1,7 +1,5 @@
 # RUM Browser Monitoring - Vue integration
 
-**Note**: This integration is in Preview. Features and configuration are subject to change.
-
 ## Overview
 
 The Datadog RUM Vue integration provides framework-specific instrumentation to help you monitor and debug Vue 3 applications. This integration adds:


### PR DESCRIPTION
## Motivation

It's been a few months since we released these integrations. Since we already have them being used regularly we can now remove the "beta" note in them. 

## Changes

Removed beta note from respective readme.md

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
