### PR TITLE
🔊 Report remote configuration sync metadata on configuration telemetry

### DIFF
--- a/packages/browser-rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/browser-rum-core/src/boot/preStartRum.spec.ts
@@ -553,7 +553,11 @@ describe('preStartRum', () => {
         it('should start the SDK with the cached configuration on cache hit', async () => {
           localStorage.setItem(
             CACHE_KEY,
-            JSON.stringify({ version: 2, config: { rum: { sessionSampleRate: 75 } }, fetchedAt: 1000 })
+            JSON.stringify({
+              version: 3,
+              config: { rum: { sessionSampleRate: 75 } },
+              metadata: { lastSynced: 1000, syncId: 'sync-id' },
+            })
           )
           const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
 

--- a/packages/browser-rum-core/src/boot/preStartRum.ts
+++ b/packages/browser-rum-core/src/boot/preStartRum.ts
@@ -31,7 +31,7 @@ import {
 } from '@datadog/browser-core'
 import type { Hooks } from '../domain/hooks'
 import { createHooks } from '../domain/hooks'
-import type { RumConfiguration, RumInitConfiguration } from '../domain/configuration'
+import type { RemoteConfigurationMetadata, RumConfiguration, RumInitConfiguration } from '../domain/configuration'
 
 import {
   fetchAndApplyRemoteConfiguration,
@@ -136,7 +136,11 @@ export function createPreStartStrategy(
     bufferApiCalls.unbuffer()
   }
 
-  function doInit(initConfiguration: RumInitConfiguration, errorStack?: string) {
+  function doInit(
+    initConfiguration: RumInitConfiguration,
+    errorStack?: string,
+    remoteConfigurationMetadata?: RemoteConfigurationMetadata
+  ) {
     const eventBridgeAvailable = canUseEventBridge()
     if (eventBridgeAvailable) {
       initConfiguration = overrideInitConfigurationForBridge(initConfiguration)
@@ -197,7 +201,7 @@ export function createPreStartStrategy(
           startTelemetrySessionContext(assembleTelemetryHook, sessionManager, {
             application: { id: configuration.applicationId },
           })
-          addTelemetryConfiguration(serializeRumConfiguration(initConfiguration, sdkName))
+          addTelemetryConfiguration(serializeRumConfiguration(initConfiguration, sdkName, remoteConfigurationMetadata))
 
           tryStartRum()
         })
@@ -275,10 +279,10 @@ export function createPreStartStrategy(
               })
               .catch(monitorError)
           } else {
-            const resolvedInitConfiguration = getRemoteConfiguration(initConfiguration, supportedContextManagers)
+            const resolvedRemoteConfiguration = getRemoteConfiguration(initConfiguration, supportedContextManagers)
 
-            if (resolvedInitConfiguration) {
-              doInit(resolvedInitConfiguration, errorStack)
+            if (resolvedRemoteConfiguration) {
+              doInit(resolvedRemoteConfiguration.initConfiguration, errorStack, resolvedRemoteConfiguration.metadata)
             }
           }
         } else {

--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -1,3 +1,4 @@
+import type { TimeStamp } from '@datadog/js-core/time'
 import type { InitConfiguration } from '@datadog/browser-core'
 import {
   addExperimentalFeatures,
@@ -799,6 +800,28 @@ describe('validateAndBuildRumConfiguration', () => {
   })
 
   describe('serializeRumConfiguration', () => {
+    describe('remote configuration metadata serialization', () => {
+      it('should serialize the applied metadata', () => {
+        const serialized = serializeRumConfiguration(DEFAULT_INIT_CONFIGURATION, undefined, {
+          lastModified: 1500,
+          lastSynced: 2000 as TimeStamp,
+          firstApplied: 3000 as TimeStamp,
+          syncId: 'sync-id',
+        })
+
+        expect(serialized.remote_configuration).toEqual({
+          last_modified: 1500,
+          last_synced: 2000 as TimeStamp,
+          first_applied: 3000 as TimeStamp,
+          sync_id: 'sync-id',
+        })
+      })
+
+      it('should omit remote_configuration when no metadata was applied', () => {
+        expect(serializeRumConfiguration(DEFAULT_INIT_CONFIGURATION).remote_configuration).toBeUndefined()
+      })
+    })
+
     describe('selected tracing propagators serialization', () => {
       it('should not return any propagator type', () => {
         expect(serializeRumConfiguration(DEFAULT_INIT_CONFIGURATION).selected_tracing_propagators).toEqual([])
@@ -1092,7 +1115,9 @@ describe('serializeRumConfiguration', () => {
         : Key extends 'trackLongTasks'
           ? 'track_long_task' // We forgot the s, keeping this for backward compatibility
           : // The following options are not reported as telemetry. Please avoid adding more of them.
-            // `remoteConfiguration` is covered by the legacy `remote_configuration_id` field.
+            // The `remoteConfiguration` init option is covered by the legacy `remote_configuration_id`
+            // field. The `remote_configuration` telemetry field is unrelated: it carries the sync
+            // metadata of the applied version, which does not come from the init configuration.
             Key extends 'applicationId' | 'subdomain' | 'remoteConfiguration' | 'sessionReplayCanvasRecording'
             ? never
             : CamelToSnakeCase<Key>
@@ -1103,6 +1128,7 @@ describe('serializeRumConfiguration', () => {
       | 'selected_tracing_propagators'
       | 'use_track_graph_ql_payload'
       | 'use_track_graph_ql_response_errors'
+      | 'remote_configuration'
     > = serializeRumConfiguration(exhaustiveRumInitConfiguration)
 
     expect(serializedConfiguration).toEqual({
@@ -1130,6 +1156,7 @@ describe('serializeRumConfiguration', () => {
       plugins: [{ name: 'foo', bar: true }],
       track_feature_flags_for_events: ['vital'],
       remote_configuration_id: '123',
+      remote_configuration: undefined,
       use_remote_configuration_proxy: true,
       profiling_sample_rate: 42,
       track_resource_headers: 'default_headers',

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -21,6 +21,7 @@ import type { SdkName } from '../contexts/defaultContext'
 import type { RumPlugin } from '../plugins'
 import type { PropagatorType, TracingOption } from '../tracing/tracer.types'
 import { getRemoteConfigurationId } from './remoteConfiguration'
+import type { RemoteConfigurationMetadata } from './remoteConfigurationCache'
 
 // replaced at build time
 declare const __BUILD_ENV__SDK_SETUP__: string
@@ -722,7 +723,11 @@ function getTrackResourceHeadersTelemetryValue(
   }
 }
 
-export function serializeRumConfiguration(configuration: RumInitConfiguration, sdkName?: SdkName) {
+export function serializeRumConfiguration(
+  configuration: RumInitConfiguration,
+  sdkName?: SdkName,
+  remoteConfigurationMetadata?: RemoteConfigurationMetadata
+) {
   const baseSerializedConfiguration = serializeConfiguration(configuration)
 
   // `use_` prefix is for telemetry options that track usage of a configuration option as a boolean to avoid capturing customer data
@@ -753,6 +758,12 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration, s
     })),
     track_feature_flags_for_events: configuration.trackFeatureFlagsForEvents,
     remote_configuration_id: getRemoteConfigurationId(configuration),
+    remote_configuration: remoteConfigurationMetadata && {
+      last_modified: remoteConfigurationMetadata.lastModified,
+      last_synced: remoteConfigurationMetadata.lastSynced,
+      first_applied: remoteConfigurationMetadata.firstApplied,
+      sync_id: remoteConfigurationMetadata.syncId,
+    },
     profiling_sample_rate: configuration.profilingSampleRate,
     use_remote_configuration_proxy: !!configuration.remoteConfigurationProxy,
     track_resource_headers: getTrackResourceHeadersTelemetryValue(configuration.trackResourceHeaders),

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -1,4 +1,5 @@
 import { ONE_MINUTE } from '@datadog/js-core/time'
+import type { TimeStamp } from '@datadog/js-core/time'
 import { DefaultPrivacyLevel, display, setCookie, deleteCookie, createContextManager } from '@datadog/browser-core'
 import { INTAKE_SITE_US1 } from '@datadog/js-core/transport'
 import { interceptRequests, registerCleanupTask } from '@datadog/browser-core/test'
@@ -898,7 +899,7 @@ describe('remoteConfiguration', () => {
 
       const result = getRemoteConfiguration(initConfiguration, supportedContextManagers)
 
-      expect(result).toBe(initConfiguration)
+      expect(result!.initConfiguration).toBe(initConfiguration)
       await flushBackgroundSync()
     })
 
@@ -909,8 +910,30 @@ describe('remoteConfiguration', () => {
       const result = getRemoteConfiguration(initConfiguration, supportedContextManagers)
 
       expect(result).toBeDefined()
-      expect(result!.applicationId).toBe('cached-app')
-      expect(result!.clientToken).toBe('xxx')
+      expect(result!.initConfiguration.applicationId).toBe('cached-app')
+      expect(result!.initConfiguration.clientToken).toBe('xxx')
+      await flushBackgroundSync()
+    })
+
+    it('should return the applied metadata on cache hit', async () => {
+      withCachedEntry(CACHED_RUM_CONFIG)
+      withFetchSuccess()
+
+      const result = getRemoteConfiguration(initConfiguration, supportedContextManagers)
+
+      expect(result!.metadata!.lastSynced).toEqual(1000 as TimeStamp)
+      expect(result!.metadata!.syncId).toBe('sync-id')
+      // exact stamping behaviour is covered in remoteConfigurationCache.spec.ts
+      expect(result!.metadata!.firstApplied!).toBeGreaterThan(0)
+      await flushBackgroundSync()
+    })
+
+    it('should not return metadata on cache miss', async () => {
+      withFetchSuccess()
+
+      const result = getRemoteConfiguration(initConfiguration, supportedContextManagers)
+
+      expect(result!.metadata).toBeUndefined()
       await flushBackgroundSync()
     })
 
@@ -920,7 +943,7 @@ describe('remoteConfiguration', () => {
 
       const result = getRemoteConfiguration(initConfiguration, supportedContextManagers)
 
-      expect(result).toBe(initConfiguration)
+      expect(result!.initConfiguration).toBe(initConfiguration)
       expect(localStorage.getItem(CACHE_KEY)).toBeNull()
       await flushBackgroundSync()
     })
@@ -993,7 +1016,7 @@ describe('remoteConfiguration', () => {
         const result = getRemoteConfiguration(initConfiguration, supportedContextManagers)
 
         expect(result).toBeDefined()
-        expect(result!.applicationId).toBe('cached-app')
+        expect(result!.initConfiguration.applicationId).toBe('cached-app')
         await flushBackgroundSync()
       })
 

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -818,7 +818,10 @@ describe('remoteConfiguration', () => {
     let displaySpy: jasmine.Spy
 
     function withCachedEntry(config: RemoteConfiguration) {
-      localStorage.setItem(CACHE_KEY, JSON.stringify({ version: CACHE_VERSION, config, fetchedAt: 1000 }))
+      localStorage.setItem(
+        CACHE_KEY,
+        JSON.stringify({ version: CACHE_VERSION, config, metadata: { lastSynced: 1000, syncId: 'sync-id' } })
+      )
     }
 
     function withFetchSuccess(config: RemoteConfiguration = FRESH_RUM_CONFIG) {

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -90,6 +90,7 @@ describe('remoteConfiguration', () => {
             defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
           },
         },
+        lastModified: undefined,
       })
     })
 
@@ -126,7 +127,47 @@ describe('remoteConfiguration', () => {
       )
 
       const fetchResult = await fetchRemoteConfiguration(configuration)
-      expect(fetchResult).toEqual({ ok: true, value: { profiling: { sampleRate: 10 } } })
+      expect(fetchResult).toEqual({ ok: true, value: { profiling: { sampleRate: 10 } }, lastModified: undefined })
+    })
+
+    describe('last-modified header', () => {
+      function withFetchReturningHeaders(headers: Record<string, string>) {
+        interceptor.withFetch(() =>
+          Promise.resolve({
+            ok: true,
+            headers: new Headers(headers),
+            json: () => Promise.resolve({ profiling: { sampleRate: 10 } }),
+          })
+        )
+      }
+
+      it('should expose the publish time as epoch milliseconds', async () => {
+        withFetchReturningHeaders({ 'last-modified': 'Wed, 21 Oct 2015 07:28:00 GMT' })
+
+        const fetchResult = await fetchRemoteConfiguration(configuration)
+
+        expect(fetchResult).toEqual({
+          ok: true,
+          value: { profiling: { sampleRate: 10 } },
+          lastModified: 1445412480000,
+        })
+      })
+
+      it('should be undefined when the header is absent', async () => {
+        withFetchReturningHeaders({})
+
+        const fetchResult = await fetchRemoteConfiguration(configuration)
+
+        expect((fetchResult as { lastModified?: number }).lastModified).toBeUndefined()
+      })
+
+      it('should be undefined when the header is not a valid date', async () => {
+        withFetchReturningHeaders({ 'last-modified': 'not-a-date' })
+
+        const fetchResult = await fetchRemoteConfiguration(configuration)
+
+        expect((fetchResult as { lastModified?: number }).lastModified).toBeUndefined()
+      })
     })
 
     it('should return an error if the remote config does not contain rum or profiling', async () => {
@@ -893,6 +934,22 @@ describe('remoteConfiguration', () => {
       const stored = JSON.parse(localStorage.getItem(CACHE_KEY)!)
       expect(stored.config).toEqual(FRESH_RUM_CONFIG)
       expect(stored.version).toBe(CACHE_VERSION)
+    })
+
+    it('should store the publish time from the background fetch response', async () => {
+      interceptor.withFetch(() =>
+        Promise.resolve({
+          ok: true,
+          headers: new Headers({ 'last-modified': 'Wed, 21 Oct 2015 07:28:00 GMT' }),
+          json: () => Promise.resolve(FRESH_RUM_CONFIG),
+        })
+      )
+
+      getRemoteConfiguration(initConfiguration, supportedContextManagers)
+      await flushBackgroundSync()
+
+      const stored = JSON.parse(localStorage.getItem(CACHE_KEY)!)
+      expect(stored.metadata.lastModified).toBe(1445412480000)
     })
 
     it('should not overwrite cache when background fetch fails', async () => {

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
@@ -7,6 +7,7 @@ import { extractRegexMatch } from '../extractRegexMatch'
 import type { RumInitConfiguration } from './configuration'
 import type { RumSdkConfig, DynamicOption, ContextItem } from './remoteConfiguration.types'
 import { parseJsonPath } from './jsonPathParser'
+import type { RemoteConfigurationMetadata } from './remoteConfigurationCache'
 import { CACHE_STATUS_TO_METRIC_MAP, createConfigurationCache } from './remoteConfigurationCache'
 
 export type RemoteConfiguration = RumSdkConfig
@@ -373,10 +374,20 @@ function doBackgroundCacheSync(
     })
 }
 
+export interface ResolvedRemoteConfiguration {
+  initConfiguration: RumInitConfiguration
+  /** Only set when a cached configuration was applied, and reported on configuration telemetry. */
+  metadata?: RemoteConfigurationMetadata
+}
+
+/**
+ * Returns `undefined` when RUM must not start, which only happens with `required: true` and no
+ * usable cache entry.
+ */
 export function getRemoteConfiguration(
   initConfiguration: RumInitConfiguration,
   supportedContextManagers: SupportedContextManagers
-): RumInitConfiguration | undefined {
+): ResolvedRemoteConfiguration | undefined {
   const configurationCache = createConfigurationCache({
     remoteConfigurationId: getRemoteConfigurationId(initConfiguration)!,
   })
@@ -389,12 +400,21 @@ export function getRemoteConfiguration(
   doBackgroundCacheSync(initConfiguration, configurationCache, metrics)
 
   if (cacheResult.status === 'hit') {
-    return applyRemoteConfiguration(initConfiguration, cacheResult.config, supportedContextManagers, metrics)
+    return {
+      // Stamping is synchronous, so it always lands before the background sync above can write.
+      metadata: configurationCache.stampFirstApplied(cacheResult),
+      initConfiguration: applyRemoteConfiguration(
+        initConfiguration,
+        cacheResult.config,
+        supportedContextManagers,
+        metrics
+      ),
+    }
   }
 
   if (initConfiguration.remoteConfiguration?.required) {
     return
   }
 
-  return initConfiguration
+  return { initConfiguration }
 }

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
@@ -288,7 +288,23 @@ function extractValue(extractor: SerializedRegex, candidate: string) {
   return extractRegexMatch(candidate, resolvedExtractor)
 }
 
-type FetchRemoteConfigurationResult = { ok: true; value: RemoteConfiguration } | { ok: false; error: Error }
+type FetchRemoteConfigurationResult =
+  { ok: true; value: RemoteConfiguration; lastModified?: number } | { ok: false; error: Error }
+
+/**
+ * Reads the CDN publish time. `Last-Modified` is a CORS-safelisted response header, so it is
+ * readable cross-origin without the CDN having to expose it explicitly. It carries an HTTP-date,
+ * so the value is only accurate to the second.
+ */
+function parseLastModified(response: Response): number | undefined {
+  const header = response.headers?.get('last-modified')
+  if (!header) {
+    return
+  }
+  const timestamp = new Date(header).getTime()
+
+  return isNaN(timestamp) ? undefined : timestamp
+}
 
 export async function fetchRemoteConfiguration(
   configuration: RumInitConfiguration
@@ -310,6 +326,7 @@ export async function fetchRemoteConfiguration(
     return {
       ok: true,
       value: remoteConfiguration,
+      lastModified: parseLastModified(response),
     }
   }
   return {
@@ -346,7 +363,7 @@ function doBackgroundCacheSync(
         display.error(fetchResult.error)
       } else {
         metrics.increment('fetch', 'success')
-        cache.write(fetchResult.value)
+        cache.write(fetchResult.value, fetchResult.lastModified)
       }
     })
     .catch(monitorError)

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.spec.ts
@@ -1,7 +1,14 @@
 import { registerCleanupTask, mockClock } from '@datadog/browser-core/test'
 import type { Clock } from '@datadog/browser-core/test'
+import type { TimeStamp } from '@datadog/js-core/time'
 import type { RemoteConfiguration } from './remoteConfiguration'
-import { buildCacheKey, createConfigurationCache, CACHE_VERSION, CACHE_KEY_PREFIX } from './remoteConfigurationCache'
+import {
+  buildCacheKey,
+  createConfigurationCache,
+  CACHE_VERSION,
+  CACHE_KEY_PREFIX,
+  type RemoteConfigurationMetadata,
+} from './remoteConfigurationCache'
 
 const REMOTE_CONFIGURATION_ID = 'test-id'
 const CACHE_KEY = `${CACHE_KEY_PREFIX}${REMOTE_CONFIGURATION_ID}`
@@ -11,6 +18,11 @@ const VALID_CONFIG: RemoteConfiguration = {
     applicationId: 'app-id',
     sessionSampleRate: 50,
   },
+}
+
+const VALID_METADATA: RemoteConfigurationMetadata = {
+  lastSynced: 1000 as TimeStamp,
+  syncId: 'sync-id',
 }
 
 describe('remoteConfigurationCache', () => {
@@ -27,14 +39,14 @@ describe('remoteConfigurationCache', () => {
         expect(cache.read()).toEqual({ status: 'miss' })
       })
 
-      it('should return hit with config when a valid entry exists', () => {
+      it('should return hit with config and metadata when a valid entry exists', () => {
         localStorage.setItem(
           CACHE_KEY,
-          JSON.stringify({ version: CACHE_VERSION, config: VALID_CONFIG, fetchedAt: 1000 })
+          JSON.stringify({ version: CACHE_VERSION, config: VALID_CONFIG, metadata: VALID_METADATA })
         )
 
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
-        expect(cache.read()).toEqual({ status: 'hit', config: VALID_CONFIG })
+        expect(cache.read()).toEqual({ status: 'hit', config: VALID_CONFIG, metadata: VALID_METADATA })
       })
 
       it('should return error and remove entry when stored data is not valid JSON', () => {
@@ -47,7 +59,10 @@ describe('remoteConfigurationCache', () => {
       })
 
       it('should return error and remove entry when version does not match', () => {
-        localStorage.setItem(CACHE_KEY, JSON.stringify({ version: 999, config: VALID_CONFIG, fetchedAt: 1000 }))
+        localStorage.setItem(
+          CACHE_KEY,
+          JSON.stringify({ version: 999, config: VALID_CONFIG, metadata: VALID_METADATA })
+        )
 
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
@@ -56,7 +71,7 @@ describe('remoteConfigurationCache', () => {
       })
 
       it('should return error and remove entry when version is missing', () => {
-        localStorage.setItem(CACHE_KEY, JSON.stringify({ config: VALID_CONFIG, fetchedAt: 1000 }))
+        localStorage.setItem(CACHE_KEY, JSON.stringify({ config: VALID_CONFIG, metadata: VALID_METADATA }))
 
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
@@ -65,7 +80,7 @@ describe('remoteConfigurationCache', () => {
       })
 
       it('should return error and remove entry when config is missing', () => {
-        localStorage.setItem(CACHE_KEY, JSON.stringify({ version: CACHE_VERSION, fetchedAt: 1000 }))
+        localStorage.setItem(CACHE_KEY, JSON.stringify({ version: CACHE_VERSION, metadata: VALID_METADATA }))
 
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
@@ -76,7 +91,7 @@ describe('remoteConfigurationCache', () => {
       it('should return error and remove entry when config is not an object', () => {
         localStorage.setItem(
           CACHE_KEY,
-          JSON.stringify({ version: CACHE_VERSION, config: 'not-an-object', fetchedAt: 1000 })
+          JSON.stringify({ version: CACHE_VERSION, config: 'not-an-object', metadata: VALID_METADATA })
         )
 
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
@@ -86,7 +101,31 @@ describe('remoteConfigurationCache', () => {
       })
 
       it('should return error and remove entry when config is null', () => {
-        localStorage.setItem(CACHE_KEY, JSON.stringify({ version: CACHE_VERSION, config: null, fetchedAt: 1000 }))
+        localStorage.setItem(
+          CACHE_KEY,
+          JSON.stringify({ version: CACHE_VERSION, config: null, metadata: VALID_METADATA })
+        )
+
+        const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
+
+        expect(cache.read()).toEqual({ status: 'error' })
+        expect(localStorage.getItem(CACHE_KEY)).toBeNull()
+      })
+
+      it('should return error and remove entry when metadata is missing', () => {
+        localStorage.setItem(CACHE_KEY, JSON.stringify({ version: CACHE_VERSION, config: VALID_CONFIG }))
+
+        const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
+
+        expect(cache.read()).toEqual({ status: 'error' })
+        expect(localStorage.getItem(CACHE_KEY)).toBeNull()
+      })
+
+      it('should return error and remove entry when metadata lacks a syncId', () => {
+        localStorage.setItem(
+          CACHE_KEY,
+          JSON.stringify({ version: CACHE_VERSION, config: VALID_CONFIG, metadata: { lastSynced: 1000 } })
+        )
 
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
@@ -105,7 +144,7 @@ describe('remoteConfigurationCache', () => {
       it('should isolate caches by remoteConfigurationId', () => {
         localStorage.setItem(
           buildCacheKey('id-A'),
-          JSON.stringify({ version: CACHE_VERSION, config: VALID_CONFIG, fetchedAt: 1000 })
+          JSON.stringify({ version: CACHE_VERSION, config: VALID_CONFIG, metadata: VALID_METADATA })
         )
 
         const cacheB = createConfigurationCache({ remoteConfigurationId: 'id-B' })
@@ -125,20 +164,28 @@ describe('remoteConfigurationCache', () => {
 
         cache.write(VALID_CONFIG)
 
-        expect(cache.read()).toEqual({ status: 'hit', config: VALID_CONFIG })
+        expect(cache.read()).toEqual({
+          status: 'hit',
+          config: VALID_CONFIG,
+          metadata: { lastSynced: clock.timeStamp(0), syncId: jasmine.any(String) as unknown as string },
+        })
       })
 
-      it('should serialize entry with version, config, and fetchedAt timestamp', () => {
+      it('should serialize entry with version, config, and sync metadata', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
         clock.tick(5000)
-        cache.write(VALID_CONFIG)
+        cache.write(VALID_CONFIG, 1500)
 
         const stored = JSON.parse(localStorage.getItem(CACHE_KEY)!)
         expect(stored).toEqual({
           version: CACHE_VERSION,
           config: VALID_CONFIG,
-          fetchedAt: clock.timeStamp(5000),
+          metadata: {
+            lastModified: 1500,
+            lastSynced: clock.timeStamp(5000),
+            syncId: jasmine.any(String) as unknown as string,
+          },
         })
       })
 
@@ -148,7 +195,36 @@ describe('remoteConfigurationCache', () => {
         cache.write({ rum: { applicationId: 'first' } })
         cache.write({ rum: { applicationId: 'second' } })
 
-        expect(cache.read()).toEqual({ status: 'hit', config: { rum: { applicationId: 'second' } } })
+        expect((cache.read() as { config: RemoteConfiguration }).config).toEqual({
+          rum: { applicationId: 'second' },
+        })
+      })
+
+      it('should regenerate sync metadata when the config changed', () => {
+        const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
+
+        cache.write({ rum: { applicationId: 'first' } }, 1500)
+        const first = (cache.read() as { metadata: RemoteConfigurationMetadata }).metadata
+
+        clock.tick(5000)
+        cache.write({ rum: { applicationId: 'second' } }, 2500)
+
+        const second = (cache.read() as { metadata: RemoteConfigurationMetadata }).metadata
+        expect(second.syncId).not.toBe(first.syncId)
+        expect(second.lastSynced).toEqual(clock.timeStamp(5000))
+        expect(second.lastModified).toBe(2500)
+      })
+
+      it('should not rewrite sync metadata when the config is unchanged', () => {
+        const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
+
+        cache.write(VALID_CONFIG, 1500)
+        const first = (cache.read() as { metadata: RemoteConfigurationMetadata }).metadata
+
+        clock.tick(5000)
+        cache.write(VALID_CONFIG, 2500)
+
+        expect((cache.read() as { metadata: RemoteConfigurationMetadata }).metadata).toEqual(first)
       })
 
       it('should silently swallow localStorage.setItem errors', () => {
@@ -164,7 +240,7 @@ describe('remoteConfigurationCache', () => {
       it('should remove the entry from localStorage', () => {
         localStorage.setItem(
           CACHE_KEY,
-          JSON.stringify({ version: CACHE_VERSION, config: VALID_CONFIG, fetchedAt: 1000 })
+          JSON.stringify({ version: CACHE_VERSION, config: VALID_CONFIG, metadata: VALID_METADATA })
         )
 
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.spec.ts
@@ -25,6 +25,15 @@ const VALID_METADATA: RemoteConfigurationMetadata = {
   syncId: 'sync-id',
 }
 
+function readHit(cache: ReturnType<typeof createConfigurationCache>) {
+  const result = cache.read()
+  if (result.status !== 'hit') {
+    throw new Error(`expected a cache hit, got '${result.status}'`)
+  }
+
+  return result
+}
+
 describe('remoteConfigurationCache', () => {
   beforeEach(() => {
     registerCleanupTask(() => {
@@ -195,21 +204,19 @@ describe('remoteConfigurationCache', () => {
         cache.write({ rum: { applicationId: 'first' } })
         cache.write({ rum: { applicationId: 'second' } })
 
-        expect((cache.read() as { config: RemoteConfiguration }).config).toEqual({
-          rum: { applicationId: 'second' },
-        })
+        expect(readHit(cache).config).toEqual({ rum: { applicationId: 'second' } })
       })
 
       it('should regenerate sync metadata when the config changed', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
         cache.write({ rum: { applicationId: 'first' } }, 1500)
-        const first = (cache.read() as { metadata: RemoteConfigurationMetadata }).metadata
+        const first = readHit(cache).metadata
 
         clock.tick(5000)
         cache.write({ rum: { applicationId: 'second' } }, 2500)
 
-        const second = (cache.read() as { metadata: RemoteConfigurationMetadata }).metadata
+        const second = readHit(cache).metadata
         expect(second.syncId).not.toBe(first.syncId)
         expect(second.lastSynced).toEqual(clock.timeStamp(5000))
         expect(second.lastModified).toBe(2500)
@@ -219,12 +226,12 @@ describe('remoteConfigurationCache', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
         cache.write(VALID_CONFIG, 1500)
-        const first = (cache.read() as { metadata: RemoteConfigurationMetadata }).metadata
+        const first = readHit(cache).metadata
 
         clock.tick(5000)
         cache.write(VALID_CONFIG, 2500)
 
-        expect((cache.read() as { metadata: RemoteConfigurationMetadata }).metadata).toEqual(first)
+        expect(readHit(cache).metadata).toEqual(first)
       })
 
       it('should silently swallow localStorage.setItem errors', () => {
@@ -233,6 +240,70 @@ describe('remoteConfigurationCache', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
         expect(() => cache.write(VALID_CONFIG)).not.toThrow()
+      })
+    })
+
+    describe('stampFirstApplied', () => {
+      let clock: Clock
+
+      beforeEach(() => {
+        clock = mockClock()
+      })
+
+      it('should stamp firstApplied and persist it when unset', () => {
+        const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
+        cache.write(VALID_CONFIG)
+
+        clock.tick(5000)
+        const metadata = cache.stampFirstApplied(readHit(cache))
+
+        expect(metadata.firstApplied).toEqual(clock.timeStamp(5000))
+        expect(readHit(cache).metadata.firstApplied).toEqual(clock.timeStamp(5000))
+        expect(readHit(cache).config).toEqual(VALID_CONFIG)
+      })
+
+      it('should reuse the firstApplied already stamped', () => {
+        const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
+        cache.write(VALID_CONFIG)
+        const first = cache.stampFirstApplied(readHit(cache))
+
+        clock.tick(60000)
+        const second = cache.stampFirstApplied(readHit(cache))
+
+        expect(second.firstApplied).toEqual(first.firstApplied)
+      })
+
+      it('should preserve firstApplied when an unchanged config is refetched', () => {
+        const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
+        cache.write(VALID_CONFIG)
+        const stamped = cache.stampFirstApplied(readHit(cache))
+
+        clock.tick(5000)
+        cache.write(VALID_CONFIG)
+
+        expect(readHit(cache).metadata.firstApplied).toEqual(stamped.firstApplied)
+      })
+
+      it('should leave firstApplied unset when the config changed', () => {
+        const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
+        cache.write({ rum: { applicationId: 'first' } })
+        cache.stampFirstApplied(readHit(cache))
+
+        cache.write({ rum: { applicationId: 'second' } })
+
+        expect(readHit(cache).metadata.firstApplied).toBeUndefined()
+      })
+
+      it('should keep the rest of the metadata intact when stamping', () => {
+        const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
+        cache.write(VALID_CONFIG, 1500)
+        const before = readHit(cache).metadata
+
+        const after = cache.stampFirstApplied(readHit(cache))
+
+        expect(after.lastModified).toBe(1500)
+        expect(after.lastSynced).toEqual(before.lastSynced)
+        expect(after.syncId).toBe(before.syncId)
       })
     })
 

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.ts
@@ -30,15 +30,17 @@ interface CachedRemoteConfiguration {
 
 export type CacheReadStatus = 'hit' | 'miss' | 'error'
 
+export interface CacheHitResult {
+  status: Extract<CacheReadStatus, 'hit'>
+  config: RemoteConfiguration
+  metadata: RemoteConfigurationMetadata
+}
+
 export type CacheReadResult =
   | {
       status: Exclude<CacheReadStatus, 'hit'>
     }
-  | {
-      status: Extract<CacheReadStatus, 'hit'>
-      config: RemoteConfiguration
-      metadata: RemoteConfigurationMetadata
-    }
+  | CacheHitResult
 
 export const CACHE_STATUS_TO_METRIC_MAP: Record<CacheReadStatus, 'success' | 'missing' | 'failure'> = {
   hit: 'success',
@@ -131,6 +133,21 @@ export function createConfigurationCache({ remoteConfigurationId }: { remoteConf
         config,
         metadata: { lastModified, lastSynced: timeStampNow(), syncId: generateUUID() },
       })
+    },
+    /**
+     * Records when this configuration version was first put into effect. Stamped on the first page
+     * load that applies it, then reused by every later one, so the reported value marks a fixed
+     * point in time instead of drifting with each page load.
+     */
+    stampFirstApplied(cached: CacheHitResult): RemoteConfigurationMetadata {
+      if (cached.metadata.firstApplied !== undefined) {
+        return cached.metadata
+      }
+
+      const metadata: RemoteConfigurationMetadata = { ...cached.metadata, firstApplied: timeStampNow() }
+      persist(key, { version: CACHE_VERSION, config: cached.config, metadata })
+
+      return metadata
     },
   }
 }

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.ts
@@ -1,15 +1,31 @@
 import { timeStampNow } from '@datadog/js-core/time'
-import { tryJsonParse } from '@datadog/browser-core'
+import { generateUUID, tryJsonParse } from '@datadog/browser-core'
+import { isIndexableObject } from '@datadog/js-core/util'
 import type { TimeStamp } from '@datadog/js-core/time'
 import type { RemoteConfiguration } from './remoteConfiguration'
 
-export const CACHE_VERSION = 2
+export const CACHE_VERSION = 3
 export const CACHE_KEY_PREFIX = 'dd_rc_'
+
+/**
+ * Sync metadata for the cached configuration version, reported on configuration telemetry to
+ * measure how long a published configuration takes to take effect.
+ */
+export interface RemoteConfigurationMetadata {
+  /** CDN publish time, from the `last-modified` response header. */
+  lastModified?: number
+  /** When the SDK fetched the version currently cached. */
+  lastSynced: TimeStamp
+  /** When this version was first applied. Stamped once, then reused on every later page load. */
+  firstApplied?: TimeStamp
+  /** Identifies one sync, so repeat page loads from a device collapse into a single unit. */
+  syncId: string
+}
 
 interface CachedRemoteConfiguration {
   version: number
   config: RemoteConfiguration
-  fetchedAt: TimeStamp
+  metadata: RemoteConfigurationMetadata
 }
 
 export type CacheReadStatus = 'hit' | 'miss' | 'error'
@@ -18,7 +34,11 @@ export type CacheReadResult =
   | {
       status: Exclude<CacheReadStatus, 'hit'>
     }
-  | { status: Extract<CacheReadStatus, 'hit'>; config: RemoteConfiguration }
+  | {
+      status: Extract<CacheReadStatus, 'hit'>
+      config: RemoteConfiguration
+      metadata: RemoteConfigurationMetadata
+    }
 
 export const CACHE_STATUS_TO_METRIC_MAP: Record<CacheReadStatus, 'success' | 'missing' | 'failure'> = {
   hit: 'success',
@@ -37,8 +57,21 @@ function isValidCacheEntry(value: unknown): value is CachedRemoteConfiguration {
 
   const hasVersion = 'version' in value && value.version === CACHE_VERSION
   const hasConfig = 'config' in value && typeof value.config === 'object' && value.config !== null
+  const hasMetadata =
+    'metadata' in value &&
+    isIndexableObject(value.metadata) &&
+    typeof value.metadata.syncId === 'string' &&
+    typeof value.metadata.lastSynced === 'number'
 
-  return hasVersion && hasConfig
+  return hasVersion && hasConfig && hasMetadata
+}
+
+function persist(key: string, entry: CachedRemoteConfiguration) {
+  try {
+    localStorage.setItem(key, JSON.stringify(entry))
+  } catch {
+    // Ignore
+  }
 }
 
 export function createConfigurationCache({ remoteConfigurationId }: { remoteConfigurationId: string }) {
@@ -71,7 +104,7 @@ export function createConfigurationCache({ remoteConfigurationId }: { remoteConf
         return { status: 'error' }
       }
 
-      return { status: 'hit', config: parsed.config }
+      return { status: 'hit', config: parsed.config, metadata: parsed.metadata }
     },
     remove() {
       try {
@@ -80,18 +113,24 @@ export function createConfigurationCache({ remoteConfigurationId }: { remoteConf
         // Ignore
       }
     },
-    write(config: RemoteConfiguration) {
-      const entry: CachedRemoteConfiguration = {
-        version: CACHE_VERSION,
-        config,
-        fetchedAt: timeStampNow(),
+    write(config: RemoteConfiguration, lastModified?: number) {
+      const cached = this.read()
+
+      // Only a payload change counts as a sync. The SDK sends no `If-None-Match`, so it never
+      // observes a 304 and cannot otherwise tell a genuine sync from a repeated fetch of the same
+      // version. Skipping the write here is also what keeps `firstApplied` alive across refetches.
+      // TODO: compare on `ETag` instead once the CDN exposes it through
+      // `Access-Control-Expose-Headers`. The stringify compare is key-order sensitive, which holds
+      // only because both sides come from `JSON.parse` of the same CDN payload.
+      if (cached.status === 'hit' && JSON.stringify(cached.config) === JSON.stringify(config)) {
+        return
       }
 
-      try {
-        localStorage.setItem(key, JSON.stringify(entry))
-      } catch {
-        // Ignore
-      }
+      persist(key, {
+        version: CACHE_VERSION,
+        config,
+        metadata: { lastModified, lastSynced: timeStampNow(), syncId: generateUUID() },
+      })
     },
   }
 }

--- a/test/e2e/scenario/rum/remoteConfiguration.scenario.ts
+++ b/test/e2e/scenario/rum/remoteConfiguration.scenario.ts
@@ -263,11 +263,12 @@ test.describe('remote configuration', () => {
 
         await page.waitForFunction((key) => localStorage.getItem(key) !== null, CACHE_KEY)
         const stored = await page.evaluate(
-          (key) => JSON.parse(localStorage.getItem(key)!) as { version: number; config: object },
+          (key) => JSON.parse(localStorage.getItem(key)!) as { version: number; config: object; metadata: object },
           CACHE_KEY
         )
-        expect(stored.version).toBe(2)
+        expect(stored.version).toBe(3)
         expect(stored.config).toEqual({ rum: { applicationId: RC_APP_ID, sessionSampleRate: 1 } })
+        expect(stored.metadata).toEqual(expect.objectContaining({ lastSynced: expect.any(Number) }))
       })
 
     createTest('should resolve an option value from a cookie')
@@ -494,7 +495,11 @@ test.describe('remote configuration', () => {
  * outer one wraps it as a valid JS string literal with proper escaping.
  */
 function seedCache(remoteConfig: RemoteConfiguration) {
-  const entry = JSON.stringify({ version: 2, config: remoteConfig, fetchedAt: 1000 })
+  const entry = JSON.stringify({
+    version: 3,
+    config: remoteConfig,
+    metadata: { lastSynced: 1000, syncId: 'e2e-sync-id' },
+  })
   return html`<script>
     localStorage.setItem('${CACHE_KEY}', ${JSON.stringify(entry)})
   </script>`


### PR DESCRIPTION
## Motivation

The remote configuration telemetry RFC wants to measure how long a published config takes to take effect on a device. Two segments: `last_synced - last_modified` for CDN to fetch, and `first_applied - last_synced` for fetch to apply. We have no visibility on either today.

The schema already merged in the events format repo and is synced here. This is the browser side.

## Changes

The metadata goes in the existing `dd_rc_<id>` localStorage entry instead of a separate key, so a version and its metadata can't drift apart on a partial write. `CACHE_VERSION` is bumped to 3 and `fetchedAt` becomes a `metadata` object with `lastModified`, `lastSynced`, `firstApplied` and `syncId`.

`sync_id` doesn't follow the RFC. The RFC regenerates it on non-304 fetches, but we send no `If-None-Match` and never see a 304. Instead `write()` compares the fetched payload with the cached one and skips the write when they match. It keys on the config changing instead of the transport, and it's also what keeps `firstApplied` from being wiped by a background refetch.

The metadata is threaded through `doInit` into `serializeRumConfiguration` instead of module state. RUM and Logs read the same cache entry once #4884 lands, so a singleton would report the wrong product's numbers.

`config_id` is not included, we already send `remote_configuration_id`. `version_id` is not included either, `x-amz-version-id` is not readable from JS.

Nothing is reported on the sync path (`sync: true` or the legacy `remoteConfigurationId`). Fetch and apply happen in the same tick there, so `first_applied - last_synced` would always be ~0. I can add it if you prefer having the CDN to fetch half for those setups. What do you think?

## Test instructions

Needs a real published remote configuration ID.

1. `yarn dev-server start`
2. Add a sandbox page with `remoteConfiguration: { id: '<rc-id>' }`, `telemetrySampleRate: 100` and `telemetryConfigurationSampleRate: 100`
3. Load it once. `localStorage.getItem('dd_rc_<rc-id>')` has `version: 3` and a `metadata` with `lastModified`, `lastSynced` and `syncId`, no `firstApplied` yet
4. Load it again. `firstApplied` is set, `lastSynced` and `syncId` unchanged
5. `agent-browser tab new` to flush, then `yarn dev-server intake telemetry-configuration-events | jq '.telemetry.configuration.remote_configuration'`

First load reports nothing, second reports the four fields:

```json
{"last_modified":1777557229000,"last_synced":1787930428705,
 "first_applied":1787930438546,"sync_id":"476d2ee9-fb31-4c30-824a-5410d4850ad0"}
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change. The existing e2e seeds the cache and checks config application, not telemetry. The two page load flow plus sampling makes it awkward, I'd rather do it separately.
- [ ] Updated documentation and/or relevant AGENTS.md file