### PR TITLE
✨ Add per-element frustration signal opt-outs

### DIFF
--- a/packages/browser-rum-core/src/domain/action/clickChain.spec.ts
+++ b/packages/browser-rum-core/src/domain/action/clickChain.spec.ts
@@ -3,6 +3,7 @@ import { mockClock } from '@datadog/browser-core/test'
 import { createFakeClick } from '../../../test'
 import type { ClickChain } from './clickChain'
 import { MAX_DISTANCE_BETWEEN_CLICKS, MAX_DURATION_BETWEEN_CLICKS, createClickChain } from './clickChain'
+import { FrustrationIgnore } from './frustrationIgnore'
 
 describe('createClickChain', () => {
   let clickChain: ClickChain | undefined
@@ -81,29 +82,18 @@ describe('createClickChain', () => {
     })
 
     it('does not accept a click if its rage ignore state is different', () => {
-      clickChain = createClickChain(
-        createFakeClick({ frustrationIgnore: { rageClick: true, deadClick: false, errorClick: false } }),
-        onFinalizeSpy
-      )
+      clickChain = createClickChain(createFakeClick({ frustrationIgnore: FrustrationIgnore.RAGE_CLICK }), onFinalizeSpy)
 
-      expect(
-        clickChain.tryAppend(
-          createFakeClick({ frustrationIgnore: { rageClick: false, deadClick: false, errorClick: false } })
-        )
-      ).toBe(false)
+      expect(clickChain.tryAppend(createFakeClick({ frustrationIgnore: FrustrationIgnore.NONE }))).toBe(false)
     })
 
     it('accepts a click if only its dead or error ignore state is different', () => {
       clickChain = createClickChain(
-        createFakeClick({ frustrationIgnore: { rageClick: false, deadClick: true, errorClick: true } }),
+        createFakeClick({ frustrationIgnore: FrustrationIgnore.DEAD_CLICK + FrustrationIgnore.ERROR_CLICK }),
         onFinalizeSpy
       )
 
-      expect(
-        clickChain.tryAppend(
-          createFakeClick({ frustrationIgnore: { rageClick: false, deadClick: false, errorClick: false } })
-        )
-      ).toBe(true)
+      expect(clickChain.tryAppend(createFakeClick({ frustrationIgnore: FrustrationIgnore.NONE }))).toBe(true)
     })
 
     it('does not accept a click if its location is far from the previous one', () => {

--- a/packages/browser-rum-core/src/domain/action/clickChain.spec.ts
+++ b/packages/browser-rum-core/src/domain/action/clickChain.spec.ts
@@ -80,6 +80,32 @@ describe('createClickChain', () => {
       expect(clickChain.tryAppend(createFakeClick({ event: { target: document.body } }))).toBe(false)
     })
 
+    it('does not accept a click if its rage ignore state is different', () => {
+      clickChain = createClickChain(
+        createFakeClick({ frustrationIgnore: { rageClick: true, deadClick: false, errorClick: false } }),
+        onFinalizeSpy
+      )
+
+      expect(
+        clickChain.tryAppend(
+          createFakeClick({ frustrationIgnore: { rageClick: false, deadClick: false, errorClick: false } })
+        )
+      ).toBe(false)
+    })
+
+    it('accepts a click if only its dead or error ignore state is different', () => {
+      clickChain = createClickChain(
+        createFakeClick({ frustrationIgnore: { rageClick: false, deadClick: true, errorClick: true } }),
+        onFinalizeSpy
+      )
+
+      expect(
+        clickChain.tryAppend(
+          createFakeClick({ frustrationIgnore: { rageClick: false, deadClick: false, errorClick: false } })
+        )
+      ).toBe(true)
+    })
+
     it('does not accept a click if its location is far from the previous one', () => {
       clickChain = createClickChain(createFakeClick({ event: { clientX: 100, clientY: 100 } }), onFinalizeSpy)
       expect(

--- a/packages/browser-rum-core/src/domain/action/clickChain.ts
+++ b/packages/browser-rum-core/src/domain/action/clickChain.ts
@@ -2,6 +2,7 @@ import type { TimeoutId } from '@datadog/browser-core'
 import { ONE_SECOND } from '@datadog/js-core/time'
 import { clearTimeout, setTimeout } from '@datadog/browser-core'
 import type { Click } from './trackClickActions'
+import { FrustrationIgnore, shouldIgnore } from './frustrationIgnore'
 
 export interface ClickChain {
   tryAppend: (click: Click) => boolean
@@ -70,7 +71,8 @@ export function createClickChain(firstClick: Click, onFinalize: (clicks: Click[]
  */
 function areClicksSimilar(first: Click, second: Click) {
   return (
-    first.frustrationIgnore.rageClick === second.frustrationIgnore.rageClick &&
+    shouldIgnore(first.ignore, FrustrationIgnore.RAGE_CLICK) ===
+      shouldIgnore(second.ignore, FrustrationIgnore.RAGE_CLICK) &&
     first.event.target === second.event.target &&
     mouseEventDistance(first.event, second.event) <= MAX_DISTANCE_BETWEEN_CLICKS &&
     first.event.timeStamp - second.event.timeStamp <= MAX_DURATION_BETWEEN_CLICKS

--- a/packages/browser-rum-core/src/domain/action/clickChain.ts
+++ b/packages/browser-rum-core/src/domain/action/clickChain.ts
@@ -51,10 +51,7 @@ export function createClickChain(firstClick: Click, onFinalize: (clicks: Click[]
         return false
       }
 
-      if (
-        bufferedClicks.length > 0 &&
-        !areEventsSimilar(bufferedClicks[bufferedClicks.length - 1].event, click.event)
-      ) {
+      if (bufferedClicks.length > 0 && !areClicksSimilar(bufferedClicks[bufferedClicks.length - 1], click)) {
         dontAcceptMoreClick()
         return false
       }
@@ -69,13 +66,14 @@ export function createClickChain(firstClick: Click, onFinalize: (clicks: Click[]
 }
 
 /**
- * Checks whether two events are similar by comparing their target, position and timestamp
+ * Checks whether two clicks are similar by comparing their rage ignore state, target, position and timestamp
  */
-function areEventsSimilar(first: MouseEvent, second: MouseEvent) {
+function areClicksSimilar(first: Click, second: Click) {
   return (
-    first.target === second.target &&
-    mouseEventDistance(first, second) <= MAX_DISTANCE_BETWEEN_CLICKS &&
-    first.timeStamp - second.timeStamp <= MAX_DURATION_BETWEEN_CLICKS
+    first.frustrationIgnore.rageClick === second.frustrationIgnore.rageClick &&
+    first.event.target === second.event.target &&
+    mouseEventDistance(first.event, second.event) <= MAX_DISTANCE_BETWEEN_CLICKS &&
+    first.event.timeStamp - second.event.timeStamp <= MAX_DURATION_BETWEEN_CLICKS
   )
 }
 

--- a/packages/browser-rum-core/src/domain/action/computeFrustration.spec.ts
+++ b/packages/browser-rum-core/src/domain/action/computeFrustration.spec.ts
@@ -5,6 +5,7 @@ import { FrustrationType } from '../../rawRumEvent.types'
 import type { FakeClick } from '../../../test'
 import { appendElement, createFakeClick } from '../../../test'
 import { computeFrustration, isRage, isDead } from './computeFrustration'
+import { FrustrationIgnore } from './frustrationIgnore'
 
 describe('computeFrustration', () => {
   let clicks: FakeClick[]
@@ -48,19 +49,28 @@ describe('computeFrustration', () => {
 
     it('does not add an ignored error frustration to the rage click', () => {
       clicksConsideredAsRage = clicksConsideredAsRage.map(() =>
-        createFakeClick({ frustrationIgnore: { rageClick: false, deadClick: false, errorClick: true } })
+        createFakeClick({ frustrationIgnore: FrustrationIgnore.ERROR_CLICK })
       )
       rageClick = createFakeClick({
         hasError: true,
-        frustrationIgnore: { rageClick: false, deadClick: false, errorClick: true },
+        frustrationIgnore: FrustrationIgnore.ERROR_CLICK,
       })
       computeFrustration(clicksConsideredAsRage, rageClick)
       expect(getFrustrations(rageClick)).toEqual([FrustrationType.RAGE_CLICK])
     })
 
-    it('adds an error frustration when at least one click does not ignore errors', () => {
+    it('uses the initiating click policy for errors during the rage click lifetime', () => {
       clicksConsideredAsRage[0] = createFakeClick({
-        frustrationIgnore: { rageClick: false, deadClick: false, errorClick: true },
+        frustrationIgnore: FrustrationIgnore.ERROR_CLICK,
+      })
+      rageClick = createFakeClick({ hasError: true, frustrationIgnore: FrustrationIgnore.ERROR_CLICK })
+      computeFrustration(clicksConsideredAsRage, rageClick)
+      expect(getFrustrations(rageClick)).toEqual([FrustrationType.RAGE_CLICK])
+    })
+
+    it('does not use a later click policy for errors during the rage click lifetime', () => {
+      clicksConsideredAsRage[1] = createFakeClick({
+        frustrationIgnore: FrustrationIgnore.ERROR_CLICK,
       })
       rageClick = createFakeClick({ hasError: true })
       computeFrustration(clicksConsideredAsRage, rageClick)

--- a/packages/browser-rum-core/src/domain/action/computeFrustration.spec.ts
+++ b/packages/browser-rum-core/src/domain/action/computeFrustration.spec.ts
@@ -45,6 +45,27 @@ describe('computeFrustration', () => {
       computeFrustration(clicksConsideredAsRage, rageClick)
       expect(getFrustrations(rageClick)).toEqual([FrustrationType.RAGE_CLICK, FrustrationType.ERROR_CLICK])
     })
+
+    it('does not add an ignored error frustration to the rage click', () => {
+      clicksConsideredAsRage = clicksConsideredAsRage.map(() =>
+        createFakeClick({ frustrationIgnore: { rageClick: false, deadClick: false, errorClick: true } })
+      )
+      rageClick = createFakeClick({
+        hasError: true,
+        frustrationIgnore: { rageClick: false, deadClick: false, errorClick: true },
+      })
+      computeFrustration(clicksConsideredAsRage, rageClick)
+      expect(getFrustrations(rageClick)).toEqual([FrustrationType.RAGE_CLICK])
+    })
+
+    it('adds an error frustration when at least one click does not ignore errors', () => {
+      clicksConsideredAsRage[0] = createFakeClick({
+        frustrationIgnore: { rageClick: false, deadClick: false, errorClick: true },
+      })
+      rageClick = createFakeClick({ hasError: true })
+      computeFrustration(clicksConsideredAsRage, rageClick)
+      expect(getFrustrations(rageClick)).toEqual([FrustrationType.RAGE_CLICK, FrustrationType.ERROR_CLICK])
+    })
   })
 
   describe('if clicks are not considered as rage', () => {
@@ -72,6 +93,13 @@ describe('computeFrustration', () => {
       clicks[1] = createFakeClick({ hasError: true })
       computeFrustration(clicks, rageClick)
       expect(getFrustrations(clicks[1])).toEqual([FrustrationType.ERROR_CLICK])
+    })
+
+    it('does not add an ignored error frustration', () => {
+      const target = appendElement('<button data-dd-ignore-frustration="error-click"></button>')
+      clicks[1] = createFakeClick({ hasError: true, event: { target } })
+      computeFrustration(clicks, rageClick)
+      expect(getFrustrations(clicks[1])).toEqual([])
     })
   })
 
@@ -130,6 +158,62 @@ describe('isRage', () => {
 
     expect(isRage(clicks)).toBe(true)
   })
+
+  it('does not consider ignored clicks as rage after the attribute is removed', () => {
+    const target = appendElement('<button data-dd-ignore-frustration></button>')
+    const clicks = [
+      createFakeClick({ event: { target } }),
+      createFakeClick({ event: { target } }),
+      createFakeClick({ event: { target } }),
+    ]
+    target.removeAttribute('data-dd-ignore-frustration')
+
+    expect(isRage(clicks)).toBe(false)
+  })
+
+  it('ignores frustration attributes on ancestors across shadow DOM boundaries', () => {
+    const host = appendElement('<div data-dd-ignore-frustration="rage-click"></div>')
+    const target = document.createElement('button')
+    host.attachShadow({ mode: 'open' }).append(target)
+    const clicks = [
+      createFakeClick({ event: { target } }),
+      createFakeClick({ event: { target } }),
+      createFakeClick({ event: { target } }),
+    ]
+
+    expect(isRage(clicks)).toBe(false)
+  })
+
+  it('only ignores the named frustration', () => {
+    const target = appendElement('<button data-dd-ignore-frustration="dead-click"></button>')
+    const clicks = [
+      createFakeClick({ event: { target } }),
+      createFakeClick({ event: { target } }),
+      createFakeClick({ event: { target } }),
+    ]
+
+    expect(isRage(clicks)).toBe(true)
+  })
+})
+
+describe('frustration ignore attribute', () => {
+  for (const attribute of ['data-dd-ignore-frustration', 'data-dd-ignore-frustration="all"']) {
+    it(`ignores every frustration type with ${attribute}`, () => {
+      const target = appendElement(`<button ${attribute}></button>`)
+      const clicks = Array.from({ length: 3 }, () =>
+        createFakeClick({ hasError: true, hasPageActivity: false, event: { target } })
+      )
+      const rageClick = createFakeClick({ hasError: true, event: { target } })
+
+      expect(computeFrustration(clicks, rageClick).isRage).toBe(false)
+      clicks.forEach((click) => expect(getFrustrations(click)).toEqual([]))
+      expect(getFrustrations(rageClick)).toEqual([])
+    })
+  }
+
+  function getFrustrations(click: FakeClick) {
+    return click.addFrustration.calls.allArgs().map((args) => args[0])
+  }
 })
 
 describe('isDead', () => {
@@ -147,6 +231,14 @@ describe('isDead', () => {
 
   it('does not consider as dead when the click is related to a "scroll" event', () => {
     expect(isDead(createFakeClick({ hasPageActivity: false, userActivity: { scroll: true } }))).toBe(false)
+  })
+
+  it('does not consider ignored clicks as dead', () => {
+    const target = appendElement(
+      '<div data-dd-ignore-frustration="rage-click dead-click"><button target></button></div>'
+    )
+
+    expect(isDead(createFakeClick({ hasPageActivity: false, event: { target } }))).toBe(false)
   })
 
   for (const { element, expected } of [

--- a/packages/browser-rum-core/src/domain/action/computeFrustration.ts
+++ b/packages/browser-rum-core/src/domain/action/computeFrustration.ts
@@ -1,6 +1,7 @@
 import { ONE_SECOND } from '@datadog/js-core/time'
 import { FrustrationType } from '../../rawRumEvent.types'
 import type { Click } from './trackClickActions'
+import { FrustrationIgnore, shouldIgnore } from './frustrationIgnore'
 
 const MIN_CLICKS_PER_SECOND_TO_CONSIDER_RAGE = 3
 
@@ -10,7 +11,8 @@ export function computeFrustration(clicks: Click[], rageClick: Click) {
     if (clicks.some(isDead)) {
       rageClick.addFrustration(FrustrationType.DEAD_CLICK)
     }
-    if (rageClick.hasError && clicks.some((click) => !click.frustrationIgnore.errorClick)) {
+    // The rage action is represented by the initiating click, so its policy applies to the whole action lifetime.
+    if (rageClick.hasError && !shouldIgnore(rageClick.ignore, FrustrationIgnore.ERROR_CLICK)) {
       rageClick.addFrustration(FrustrationType.ERROR_CLICK)
     }
     return { isRage: true }
@@ -18,7 +20,7 @@ export function computeFrustration(clicks: Click[], rageClick: Click) {
 
   const hasSelectionChanged = clicks.some((click) => click.getUserActivity().selection)
   clicks.forEach((click) => {
-    if (click.hasError && !click.frustrationIgnore.errorClick) {
+    if (click.hasError && !shouldIgnore(click.ignore, FrustrationIgnore.ERROR_CLICK)) {
       click.addFrustration(FrustrationType.ERROR_CLICK)
     }
     if (
@@ -36,7 +38,9 @@ export function isRage(clicks: Click[]) {
   if (
     clicks.some(
       (click) =>
-        click.frustrationIgnore.rageClick || click.getUserActivity().selection || click.getUserActivity().scroll
+        shouldIgnore(click.ignore, FrustrationIgnore.RAGE_CLICK) ||
+        click.getUserActivity().selection ||
+        click.getUserActivity().scroll
     )
   ) {
     return false
@@ -69,7 +73,7 @@ const DEAD_CLICK_EXCLUDE_SELECTOR =
   'a[href] *'
 
 export function isDead(click: Click) {
-  if (click.frustrationIgnore.deadClick) {
+  if (shouldIgnore(click.ignore, FrustrationIgnore.DEAD_CLICK)) {
     return false
   }
 

--- a/packages/browser-rum-core/src/domain/action/computeFrustration.ts
+++ b/packages/browser-rum-core/src/domain/action/computeFrustration.ts
@@ -10,7 +10,7 @@ export function computeFrustration(clicks: Click[], rageClick: Click) {
     if (clicks.some(isDead)) {
       rageClick.addFrustration(FrustrationType.DEAD_CLICK)
     }
-    if (rageClick.hasError) {
+    if (rageClick.hasError && clicks.some((click) => !click.frustrationIgnore.errorClick)) {
       rageClick.addFrustration(FrustrationType.ERROR_CLICK)
     }
     return { isRage: true }
@@ -18,7 +18,7 @@ export function computeFrustration(clicks: Click[], rageClick: Click) {
 
   const hasSelectionChanged = clicks.some((click) => click.getUserActivity().selection)
   clicks.forEach((click) => {
-    if (click.hasError) {
+    if (click.hasError && !click.frustrationIgnore.errorClick) {
       click.addFrustration(FrustrationType.ERROR_CLICK)
     }
     if (
@@ -33,7 +33,12 @@ export function computeFrustration(clicks: Click[], rageClick: Click) {
 }
 
 export function isRage(clicks: Click[]) {
-  if (clicks.some((click) => click.getUserActivity().selection || click.getUserActivity().scroll)) {
+  if (
+    clicks.some(
+      (click) =>
+        click.frustrationIgnore.rageClick || click.getUserActivity().selection || click.getUserActivity().scroll
+    )
+  ) {
     return false
   }
   for (let i = 0; i < clicks.length - (MIN_CLICKS_PER_SECOND_TO_CONSIDER_RAGE - 1); i += 1) {
@@ -64,6 +69,10 @@ const DEAD_CLICK_EXCLUDE_SELECTOR =
   'a[href] *'
 
 export function isDead(click: Click) {
+  if (click.frustrationIgnore.deadClick) {
+    return false
+  }
+
   if (click.hasPageActivity || click.getUserActivity().input || click.getUserActivity().scroll) {
     return false
   }

--- a/packages/browser-rum-core/src/domain/action/frustrationIgnore.ts
+++ b/packages/browser-rum-core/src/domain/action/frustrationIgnore.ts
@@ -14,9 +14,9 @@ export const enum FrustrationIgnore {
   ALL = 7,
 }
 
-export function shouldIgnore(ignore: FrustrationIgnore, frustration: number) {
+export function shouldIgnore(ignoredFrustrations: FrustrationIgnore, frustration: FrustrationIgnore) {
   // eslint-disable-next-line no-bitwise
-  return (ignore & frustration) !== 0
+  return (ignoredFrustrations & frustration) !== 0
 }
 
 export function getFrustrationIgnore(element: Element): FrustrationIgnore {

--- a/packages/browser-rum-core/src/domain/action/frustrationIgnore.ts
+++ b/packages/browser-rum-core/src/domain/action/frustrationIgnore.ts
@@ -6,14 +6,21 @@ const RAGE_CLICK_IGNORE_VALUE = 'rage-click'
 const DEAD_CLICK_IGNORE_VALUE = 'dead-click'
 const ERROR_CLICK_IGNORE_VALUE = 'error-click'
 
-export interface FrustrationIgnore {
-  rageClick: boolean
-  deadClick: boolean
-  errorClick: boolean
+export const enum FrustrationIgnore {
+  NONE = 0,
+  RAGE_CLICK = 1,
+  DEAD_CLICK = 2,
+  ERROR_CLICK = 4,
+  ALL = 7,
+}
+
+export function shouldIgnore(ignore: FrustrationIgnore, frustration: number) {
+  // eslint-disable-next-line no-bitwise
+  return (ignore & frustration) !== 0
 }
 
 export function getFrustrationIgnore(element: Element): FrustrationIgnore {
-  const frustrationIgnore = { rageClick: false, deadClick: false, errorClick: false }
+  let frustrationIgnore = FrustrationIgnore.NONE
   let currentElement: Element | null = element
 
   while (currentElement) {
@@ -21,17 +28,23 @@ export function getFrustrationIgnore(element: Element): FrustrationIgnore {
     if (attributeValue !== null) {
       const values = attributeValue.split(/\s+/)
       const ignoreAll = attributeValue.trim() === '' || values.includes(ALL_FRUSTRATIONS_IGNORE_VALUE)
-      if (ignoreAll || values.includes(RAGE_CLICK_IGNORE_VALUE)) {
-        frustrationIgnore.rageClick = true
+      if (ignoreAll) {
+        return FrustrationIgnore.ALL
       }
-      if (ignoreAll || values.includes(DEAD_CLICK_IGNORE_VALUE)) {
-        frustrationIgnore.deadClick = true
+      if (values.includes(RAGE_CLICK_IGNORE_VALUE)) {
+        // eslint-disable-next-line no-bitwise
+        frustrationIgnore |= FrustrationIgnore.RAGE_CLICK
       }
-      if (ignoreAll || values.includes(ERROR_CLICK_IGNORE_VALUE)) {
-        frustrationIgnore.errorClick = true
+      if (values.includes(DEAD_CLICK_IGNORE_VALUE)) {
+        // eslint-disable-next-line no-bitwise
+        frustrationIgnore |= FrustrationIgnore.DEAD_CLICK
+      }
+      if (values.includes(ERROR_CLICK_IGNORE_VALUE)) {
+        // eslint-disable-next-line no-bitwise
+        frustrationIgnore |= FrustrationIgnore.ERROR_CLICK
       }
     }
-    if (frustrationIgnore.rageClick && frustrationIgnore.deadClick && frustrationIgnore.errorClick) {
+    if (frustrationIgnore === FrustrationIgnore.ALL) {
       break
     }
     currentElement = getParentElement(currentElement)

--- a/packages/browser-rum-core/src/domain/action/frustrationIgnore.ts
+++ b/packages/browser-rum-core/src/domain/action/frustrationIgnore.ts
@@ -1,0 +1,41 @@
+import { getParentElement } from '../../browser/htmlDomUtils'
+
+const FRUSTRATION_IGNORE_ATTRIBUTE = 'data-dd-ignore-frustration'
+const ALL_FRUSTRATIONS_IGNORE_VALUE = 'all'
+const RAGE_CLICK_IGNORE_VALUE = 'rage-click'
+const DEAD_CLICK_IGNORE_VALUE = 'dead-click'
+const ERROR_CLICK_IGNORE_VALUE = 'error-click'
+
+export interface FrustrationIgnore {
+  rageClick: boolean
+  deadClick: boolean
+  errorClick: boolean
+}
+
+export function getFrustrationIgnore(element: Element): FrustrationIgnore {
+  const frustrationIgnore = { rageClick: false, deadClick: false, errorClick: false }
+  let currentElement: Element | null = element
+
+  while (currentElement) {
+    const attributeValue = currentElement.getAttribute(FRUSTRATION_IGNORE_ATTRIBUTE)
+    if (attributeValue !== null) {
+      const values = attributeValue.split(/\s+/)
+      const ignoreAll = attributeValue.trim() === '' || values.includes(ALL_FRUSTRATIONS_IGNORE_VALUE)
+      if (ignoreAll || values.includes(RAGE_CLICK_IGNORE_VALUE)) {
+        frustrationIgnore.rageClick = true
+      }
+      if (ignoreAll || values.includes(DEAD_CLICK_IGNORE_VALUE)) {
+        frustrationIgnore.deadClick = true
+      }
+      if (ignoreAll || values.includes(ERROR_CLICK_IGNORE_VALUE)) {
+        frustrationIgnore.errorClick = true
+      }
+    }
+    if (frustrationIgnore.rageClick && frustrationIgnore.deadClick && frustrationIgnore.errorClick) {
+      break
+    }
+    currentElement = getParentElement(currentElement)
+  }
+
+  return frustrationIgnore
+}

--- a/packages/browser-rum-core/src/domain/action/trackClickActions.spec.ts
+++ b/packages/browser-rum-core/src/domain/action/trackClickActions.spec.ts
@@ -372,6 +372,21 @@ describe('trackClickActions', () => {
         ])
       )
     })
+
+    it('captures the rage ignore state before the attribute changes', () => {
+      button.setAttribute('data-dd-ignore-frustration', '')
+      startClickActionsTracking()
+
+      emulateClick({ activity: {} })
+      emulateClick({ activity: {} })
+      emulateClick({ activity: {} })
+      button.removeAttribute('data-dd-ignore-frustration')
+
+      clock.tick(EXPIRE_DELAY)
+      expect(events).toHaveSize(3)
+      events.forEach((event) => expect(event.frustrationTypes).not.toContain(FrustrationType.RAGE_CLICK))
+    })
+
   })
 
   describe('error clicks', () => {
@@ -384,6 +399,18 @@ describe('trackClickActions', () => {
       clock.tick(EXPIRE_DELAY)
       expect(events.length).toBe(1)
       expect(events[0].frustrationTypes).toEqual([FrustrationType.ERROR_CLICK])
+    })
+
+    it('does not consider an ignored error as an error click', () => {
+      button.setAttribute('data-dd-ignore-frustration', 'error-click')
+      startClickActionsTracking()
+
+      emulateClick({ activity: {} })
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, createFakeErrorEvent())
+
+      clock.tick(EXPIRE_DELAY)
+      expect(events).toHaveSize(1)
+      expect(events[0].frustrationTypes).not.toContain(FrustrationType.ERROR_CLICK)
     })
 
     it('considers a "click without activity" followed by an error as a click action with "error" (and "dead") frustration type', () => {
@@ -666,6 +693,37 @@ describe('trackClickActions', () => {
       expect(events.length).toBe(1)
       expect(events[0].target?.selector).toContain(SHADOW_DOM_MARKER)
       expect(events[0].target?.selector).toContain('BUTTON')
+    })
+
+    it('does not use an ignored click as the basis of a rage action', () => {
+      shadowButton.setAttribute('data-dd-ignore-frustration', 'rage-click')
+      const contributingButton = document.createElement('button')
+      contributingButton.textContent = 'Contributing Button'
+      shadowHost.shadowRoot!.appendChild(contributingButton)
+      startClickActionsTracking()
+
+      emulateShadowClick(shadowButton)
+      emulateShadowClick(contributingButton)
+      emulateShadowClick(contributingButton)
+      emulateShadowClick(contributingButton)
+
+      clock.tick(EXPIRE_DELAY)
+      expect(events).toHaveSize(2)
+      expect(events[0].frustrationTypes).not.toContain(FrustrationType.RAGE_CLICK)
+      expect(events[1].frustrationTypes).toContain(FrustrationType.RAGE_CLICK)
+      expect(events[1].name).toBe('Contributing Button')
+      expect(events[1].events).toHaveSize(3)
+
+      function emulateShadowClick(target: HTMLButtonElement) {
+        emulateClick({
+          target: shadowHost,
+          activity: { delay: 5 },
+          eventProperty: {
+            composed: true,
+            composedPath: () => [target, shadowHost.shadowRoot, shadowHost, document.body, document],
+          },
+        })
+      }
     })
   })
 

--- a/packages/browser-rum-core/src/domain/action/trackClickActions.spec.ts
+++ b/packages/browser-rum-core/src/domain/action/trackClickActions.spec.ts
@@ -426,6 +426,21 @@ describe('trackClickActions', () => {
       expect(events[0].frustrationTypes).not.toContain(FrustrationType.ERROR_CLICK)
     })
 
+    it('captures the ignore state from the pointer-down element', () => {
+      button.setAttribute('data-dd-ignore-frustration', 'error-click')
+      startClickActionsTracking()
+
+      emulateClick({
+        activity: {},
+        afterPointerDown: () => button.removeAttribute('data-dd-ignore-frustration'),
+      })
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, createFakeErrorEvent())
+
+      clock.tick(EXPIRE_DELAY)
+      expect(events).toHaveSize(1)
+      expect(events[0].frustrationTypes).not.toContain(FrustrationType.ERROR_CLICK)
+    })
+
     it('considers a "click without activity" followed by an error as a click action with "error" (and "dead") frustration type', () => {
       startClickActionsTracking()
 
@@ -605,6 +620,7 @@ describe('trackClickActions', () => {
     target = button,
     activity,
     eventProperty,
+    afterPointerDown,
   }: {
     target?: HTMLElement
     activity?: {
@@ -612,6 +628,7 @@ describe('trackClickActions', () => {
       on?: 'pointerup' | 'click' | 'pointerdown'
     }
     eventProperty?: { [key: string]: any }
+    afterPointerDown?: () => void
   } = {}) {
     const targetPosition = target.getBoundingClientRect()
     const offsetX = targetPosition.width / 2
@@ -626,6 +643,7 @@ describe('trackClickActions', () => {
       ...eventProperty,
     }
     target.dispatchEvent(createNewEvent('pointerdown', { ...baseEventProperties, timeStamp: relativeNow() }))
+    afterPointerDown?.()
     emulateActivityIfNeeded('pointerdown')
     clock!.tick(EMULATED_CLICK_DURATION)
     target.dispatchEvent(createNewEvent('pointerup', { ...baseEventProperties, timeStamp: relativeNow() }))

--- a/packages/browser-rum-core/src/domain/action/trackClickActions.spec.ts
+++ b/packages/browser-rum-core/src/domain/action/trackClickActions.spec.ts
@@ -387,6 +387,19 @@ describe('trackClickActions', () => {
       events.forEach((event) => expect(event.frustrationTypes).not.toContain(FrustrationType.RAGE_CLICK))
     })
 
+    it('keeps the current chain when a previous chain finalizes', () => {
+      startClickActionsTracking()
+
+      emulateClick({ target: emptyElement })
+      emulateClick({ activity: { delay: 5 } })
+      emulateClick({ activity: { delay: 5 } })
+      emulateClick({ activity: { delay: 5 } })
+
+      clock.tick(EXPIRE_DELAY)
+      const rageActions = events.filter((event) => event.frustrationTypes.includes(FrustrationType.RAGE_CLICK))
+      expect(rageActions).toHaveSize(1)
+      expect(rageActions[0].events).toHaveSize(3)
+    })
   })
 
   describe('error clicks', () => {

--- a/packages/browser-rum-core/src/domain/action/trackClickActions.ts
+++ b/packages/browser-rum-core/src/domain/action/trackClickActions.ts
@@ -68,11 +68,12 @@ export function trackClickActions(
 
   const { stop: stopActionEventsListener } = listenActionEvents<{
     clickActionBase: ClickActionBase
+    ignore: FrustrationIgnore
     hadActivityOnPointerDown: () => boolean
   }>({
     onPointerDown: (pointerDownEvent) =>
       processPointerDown(configuration, lifeCycle, domMutationObservable, pointerDownEvent, windowOpenObservable),
-    onPointerUp: ({ clickActionBase, hadActivityOnPointerDown }, startEvent, getUserActivity) => {
+    onPointerUp: ({ clickActionBase, ignore, hadActivityOnPointerDown }, startEvent, getUserActivity) => {
       startClickAction(
         configuration,
         lifeCycle,
@@ -82,6 +83,7 @@ export function trackClickActions(
         stopObservable,
         appendClickToClickChain,
         clickActionBase,
+        ignore,
         startEvent,
         getUserActivity,
         hadActivityOnPointerDown
@@ -159,7 +161,11 @@ function processPointerDown(
     PAGE_ACTIVITY_VALIDATION_DELAY
   )
 
-  return { clickActionBase, hadActivityOnPointerDown: () => hadActivityOnPointerDown }
+  return {
+    clickActionBase,
+    ignore: getFrustrationIgnore(getEventTarget(pointerDownEvent)),
+    hadActivityOnPointerDown: () => hadActivityOnPointerDown,
+  }
 }
 
 function startClickAction(
@@ -171,11 +177,12 @@ function startClickAction(
   stopObservable: Observable<void>,
   appendClickToClickChain: (click: Click) => void,
   clickActionBase: ClickActionBase,
+  ignore: FrustrationIgnore,
   startEvent: MouseEventOnElement,
   getUserActivity: () => UserActivity,
   hadActivityOnPointerDown: () => boolean
 ) {
-  const click = newClick(lifeCycle, actionTracker, getUserActivity, clickActionBase, startEvent)
+  const click = newClick(lifeCycle, actionTracker, getUserActivity, clickActionBase, ignore, startEvent)
   appendClickToClickChain(click)
 
   const selector = clickActionBase?.target?.selector
@@ -293,12 +300,11 @@ function newClick(
   actionTracker: EventTracker<ClickActionBase>,
   getUserActivity: () => UserActivity,
   clickActionBase: ClickActionBase,
-  startEvent: MouseEventOnElement,
-  frustrationIgnore?: FrustrationIgnore
+  ignore: FrustrationIgnore,
+  startEvent: MouseEventOnElement
 ) {
   const clickKey = generateUUID()
   const startClocks = relativeToClocks(startEvent.timeStamp)
-  const capturedFrustrationIgnore = frustrationIgnore ?? getFrustrationIgnore(getEventTarget(startEvent))
 
   const startedClickAction = actionTracker.start(clickKey, startClocks, clickActionBase, {
     isChildEvent: isActionChildEvent,
@@ -327,7 +333,7 @@ function newClick(
 
   return {
     event: startEvent,
-    frustrationIgnore: capturedFrustrationIgnore,
+    ignore,
     stop,
     stopObservable,
 
@@ -348,8 +354,7 @@ function newClick(
 
     isStopped: () => status === ClickStatus.STOPPED || status === ClickStatus.FINALIZED,
 
-    clone: () =>
-      newClick(lifeCycle, actionTracker, getUserActivity, clickActionBase, startEvent, capturedFrustrationIgnore),
+    clone: () => newClick(lifeCycle, actionTracker, getUserActivity, clickActionBase, ignore, startEvent),
 
     validate: (domEvents?: Event[]) => {
       stop()

--- a/packages/browser-rum-core/src/domain/action/trackClickActions.ts
+++ b/packages/browser-rum-core/src/domain/action/trackClickActions.ts
@@ -18,6 +18,8 @@ import { getComposedPathSelector } from '../getComposedPathSelector'
 import type { ClickChain } from './clickChain'
 import { createClickChain } from './clickChain'
 import { getActionNameFromElement } from './getActionNameFromElement'
+import type { FrustrationIgnore } from './frustrationIgnore'
+import { getFrustrationIgnore } from './frustrationIgnore'
 import type { ActionNameSource } from './actionNameConstants'
 import type { MouseEventOnElement, UserActivity } from './listenActionEvents'
 import { listenActionEvents } from './listenActionEvents'
@@ -287,10 +289,12 @@ function newClick(
   actionTracker: EventTracker<ClickActionBase>,
   getUserActivity: () => UserActivity,
   clickActionBase: ClickActionBase,
-  startEvent: MouseEventOnElement
+  startEvent: MouseEventOnElement,
+  frustrationIgnore?: FrustrationIgnore
 ) {
   const clickKey = generateUUID()
   const startClocks = relativeToClocks(startEvent.timeStamp)
+  const capturedFrustrationIgnore = frustrationIgnore ?? getFrustrationIgnore(getEventTarget(startEvent))
 
   const startedClickAction = actionTracker.start(clickKey, startClocks, clickActionBase, {
     isChildEvent: isActionChildEvent,
@@ -319,6 +323,7 @@ function newClick(
 
   return {
     event: startEvent,
+    frustrationIgnore: capturedFrustrationIgnore,
     stop,
     stopObservable,
 
@@ -339,7 +344,8 @@ function newClick(
 
     isStopped: () => status === ClickStatus.STOPPED || status === ClickStatus.FINALIZED,
 
-    clone: () => newClick(lifeCycle, actionTracker, getUserActivity, clickActionBase, startEvent),
+    clone: () =>
+      newClick(lifeCycle, actionTracker, getUserActivity, clickActionBase, startEvent, capturedFrustrationIgnore),
 
     validate: (domEvents?: Event[]) => {
       stop()

--- a/packages/browser-rum-core/src/domain/action/trackClickActions.ts
+++ b/packages/browser-rum-core/src/domain/action/trackClickActions.ts
@@ -102,13 +102,17 @@ export function trackClickActions(
   function appendClickToClickChain(click: Click) {
     if (!currentClickChain?.tryAppend(click)) {
       const rageClick = click.clone()
-      currentClickChain = createClickChain(click, (clicks) => {
+      const clickChain = createClickChain(click, (clicks) => {
         finalizeClicks(clicks, rageClick)
         // Clear the reference to allow garbage collection. Without this, the finalize callback
         // retains a closure reference to the old click chain, preventing it from being cleaned up
         // and causing a memory leak as click chains accumulate over time.
-        currentClickChain = undefined
+        // Only clear it if no newer chain has replaced it.
+        if (currentClickChain === clickChain) {
+          currentClickChain = undefined
+        }
       })
+      currentClickChain = clickChain
     }
   }
 

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -267,6 +267,8 @@ export interface RumInitConfiguration extends InitConfiguration {
   /**
    * Enables automatic collection of users actions.
    *
+   * Add `data-dd-ignore-frustration` without a value, or set it to `all`, to ignore all frustration signals for an element and its descendants. To ignore specific signals, use a space-separated list of `rage-click`, `dead-click`, and `error-click`.
+   *
    * See [Tracking User Actions](https://docs.datadoghq.com/real_user_monitoring/browser/tracking_user_actions) for further information.
    *
    * @category Data Collection

--- a/packages/browser-rum-core/test/createFakeClick.ts
+++ b/packages/browser-rum-core/test/createFakeClick.ts
@@ -49,7 +49,7 @@ export function createFakeClick({
     }),
     addFrustration: jasmine.createSpy<Click['addFrustration']>(),
     clone: jasmine.createSpy<typeof clone>().and.callFake(clone),
-    frustrationIgnore: capturedFrustrationIgnore,
+    ignore: capturedFrustrationIgnore,
 
     event: createNewEvent('pointerup', {
       clientX: 100,

--- a/packages/browser-rum-core/test/createFakeClick.ts
+++ b/packages/browser-rum-core/test/createFakeClick.ts
@@ -2,6 +2,8 @@ import { clocksNow, timeStampNow } from '@datadog/js-core/time'
 import { Observable } from '@datadog/browser-core'
 import { createNewEvent } from '@datadog/browser-core/test'
 import type { Click } from '../src/domain/action/trackClickActions'
+import type { FrustrationIgnore } from '../src/domain/action/frustrationIgnore'
+import { getFrustrationIgnore } from '../src/domain/action/frustrationIgnore'
 import type { MouseEventOnElement, UserActivity } from '../src/domain/action/listenActionEvents'
 
 export type FakeClick = Readonly<ReturnType<typeof createFakeClick>>
@@ -11,17 +13,20 @@ export function createFakeClick({
   hasPageActivity = true,
   userActivity,
   event,
+  frustrationIgnore,
 }: {
   hasError?: boolean
   hasPageActivity?: boolean
   userActivity?: Partial<UserActivity>
   event?: Partial<MouseEventOnElement>
+  frustrationIgnore?: FrustrationIgnore
 } = {}) {
   const stopObservable = new Observable<void>()
   let isStopped = false
+  const capturedFrustrationIgnore = frustrationIgnore ?? getFrustrationIgnore(event?.target ?? document.body)
 
   function clone() {
-    return createFakeClick({ userActivity, event })
+    return createFakeClick({ userActivity, event, frustrationIgnore: capturedFrustrationIgnore })
   }
 
   return {
@@ -44,6 +49,7 @@ export function createFakeClick({
     }),
     addFrustration: jasmine.createSpy<Click['addFrustration']>(),
     clone: jasmine.createSpy<typeof clone>().and.callFake(clone),
+    frustrationIgnore: capturedFrustrationIgnore,
 
     event: createNewEvent('pointerup', {
       clientX: 100,


### PR DESCRIPTION
## Motivation

Some interactive elements legitimately generate repeated clicks or do not trigger activity the SDK can observe. Applications need a way to exclude those interactions from frustration classification without disabling action tracking.

## Changes

Adds data-dd-ignore-frustration for an element and its descendants.

- Use the attribute without a value, or with all, to ignore every frustration type.
- Use rage-click, dead-click, and error-click as space-separated values to ignore selected types.
- Capture the ignore policy when the click happens, including for elements in Shadow DOM.

## Test instructions

Run yarn test:unit.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file