### PR TITLE
🐛 [RUMS-6286] avoid fallback trace sampling in WebViews

### DIFF
--- a/packages/browser-rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/browser-rum-core/src/domain/tracing/tracer.spec.ts
@@ -1,7 +1,7 @@
 import type { ContextManager, ContextValue } from '@datadog/browser-core'
 import { display, objectEntries, TraceContextInjection } from '@datadog/browser-core'
 import type { SessionManagerMock } from '@datadog/browser-core/test'
-import { MID_HASH_UUID, MOCK_SESSION_ID, createSessionManagerMock } from '@datadog/browser-core/test'
+import { MID_HASH_UUID, MOCK_SESSION_ID, createSessionManagerMock, mockEventBridge } from '@datadog/browser-core/test'
 import type { RumFetchResolveContext, RumFetchStartContext, RumXhrStartContext } from '../requestCollection'
 import type { RumInitConfiguration } from '../configuration'
 import { validateAndBuildRumConfiguration } from '../configuration'
@@ -108,6 +108,20 @@ describe('tracer', () => {
       expect(context.traceId).toBeDefined()
       expect(context.spanId).toBeDefined()
       expect(xhr.headers).toEqual(tracingHeadersFor(context.traceId!, context.spanId!, '1'))
+    })
+
+    it('should not trace request in a WebView when the native sampling decision is unavailable', () => {
+      mockEventBridge()
+      const tracer = startTracerWithDefaults({
+        initConfiguration: { traceSampleRate: 100 },
+      })
+      const context = { ...ALLOWED_DOMAIN_CONTEXT }
+      tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
+
+      expect(context.traceSampled).toBeUndefined()
+      expect(context.traceId).toBeUndefined()
+      expect(context.spanId).toBeUndefined()
+      expect(xhr.headers).toEqual({})
     })
 
     it("should trace request with priority '0' when not sampled and config set to all", () => {
@@ -681,6 +695,20 @@ describe('tracer', () => {
       expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-parent-id']))
       expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-trace-id']))
       expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-sampling-priority']))
+    })
+
+    it('should not trace request in a WebView when the native sampling decision is unavailable', () => {
+      mockEventBridge()
+      const tracer = startTracerWithDefaults({
+        initConfiguration: { traceSampleRate: 100 },
+      })
+      const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
+      tracer.traceFetch(context)
+
+      expect(context.traceSampled).toBeUndefined()
+      expect(context.traceId).toBeUndefined()
+      expect(context.spanId).toBeUndefined()
+      expect(context.init).toBeUndefined()
     })
 
     it('should add headers when trace not sampled and config set to all', () => {

--- a/packages/browser-rum-core/src/domain/tracing/tracer.ts
+++ b/packages/browser-rum-core/src/domain/tracing/tracer.ts
@@ -136,13 +136,11 @@ function injectHeadersIfTracingAllowed(
     return
   }
 
-  const fallbackTraceSampled = isSampled(
-    session.id,
-    correctedChildSampleRate(configuration.sessionSampleRate, configuration.traceSampleRate)
-  )
+  // The native SDK owns the sampling decision in a WebView. If its decision is not available,
+  // do not fall back to an independent Browser SDK decision because the two decisions can differ.
   const traceSampled = canUseEventBridge()
-    ? (getEventBridge()?.getIsTraceSampled() ?? fallbackTraceSampled)
-    : fallbackTraceSampled
+    ? (getEventBridge()?.getIsTraceSampled() ?? false)
+    : isSampled(session.id, correctedChildSampleRate(configuration.sessionSampleRate, configuration.traceSampleRate))
 
   const shouldInjectHeaders = traceSampled || configuration.traceContextInjection === TraceContextInjection.ALL
   if (!shouldInjectHeaders) {

--- a/test/e2e/scenario/eventBridge.scenario.ts
+++ b/test/e2e/scenario/eventBridge.scenario.ts
@@ -129,6 +129,18 @@ test.describe('bridge present', () => {
       expect(xhrResources[0]._dd?.trace_id).toBeUndefined()
     })
 
+  createTest('do not trace when bridge does not provide a sampling decision')
+    .withRum({ service: 'service', traceSampleRate: 100, allowedTracingUrls: ['LOCATION_ORIGIN'] })
+    .withEventBridge()
+    .run(async ({ flushEvents, intakeRegistry, sendXhr }) => {
+      await sendXhr('/headers')
+      await flushEvents()
+
+      const xhrResources = intakeRegistry.rumResourceEvents.filter((event) => event.resource.type === 'xhr')
+      expect(xhrResources).toHaveLength(1)
+      expect(xhrResources[0]._dd?.trace_id).toBeUndefined()
+    })
+
   createTest('do not send records when the recording is stopped')
     .withRum()
     .withEventBridge()


### PR DESCRIPTION
## Motivation

In WebViews, the native SDK owns the trace sampling decision. When that decision is temporarily unavailable, the Browser SDK currently falls back to its own sampling decision. The two decisions can differ and produce inconsistent tracing for the same mobile session.

This addresses [RUMS-6286](https://datadoghq.atlassian.net/browse/RUMS-6286).

## Changes

- Treat a missing native trace sampling decision as not sampled when the event bridge is active.
- Keep the Browser SDK sampling decision for non-WebView usage.
- Add unit coverage for XHR and Fetch requests.
- Add E2E coverage for an event bridge without a native sampling decision.

The implementation and tests were prepared with Codex.

## Test instructions

- `yarn test:unit --spec packages/browser-rum-core/src/domain/tracing/tracer.spec.ts` — 43 tests passed.
- ESLint passed on the three changed files.
- Prettier passed on the three changed files.
- TypeScript passed for the changed tracing files and the E2E project.
- The focused E2E run could not start locally because the Next.js test-app dependency is not installed (`next: command not found`).

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file


[RUMS-6286]: https://datadoghq.atlassian.net/browse/RUMS-6286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ