### PR TITLE
♻️ Merge message context into raw logs event at collection time

### DIFF
--- a/packages/browser-logs/src/domain/assembly.spec.ts
+++ b/packages/browser-logs/src/domain/assembly.spec.ts
@@ -85,19 +85,6 @@ describe('startLogsAssembly', () => {
   })
 
   describe('contexts inclusion', () => {
-    it('should include message context', () => {
-      spyOn(window.DD_RUM!, 'getInternalContext').and.returnValue({
-        view: { url: 'http://from-rum-context.com', id: 'view-id' },
-      })
-
-      lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
-        rawLogsEvent: DEFAULT_MESSAGE,
-        messageContext: { foo: 'from-message-context' },
-      })
-
-      expect(serverLogs[0].foo).toEqual('from-message-context')
-    })
-
     it('should include common context', () => {
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE })
 
@@ -223,15 +210,6 @@ describe('startLogsAssembly', () => {
 
       expect(serverLogs[0].message).toEqual('message')
     })
-
-    it('message context should take precedence over raw log', () => {
-      lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
-        rawLogsEvent: DEFAULT_MESSAGE,
-        messageContext: { message: 'from-message-context' },
-      })
-
-      expect(serverLogs[0].message).toEqual('from-message-context')
-    })
   })
 
   describe('ddtags', () => {
@@ -320,24 +298,17 @@ describe('logs limitation', () => {
     expect(serverLogs[1].message).toBe('bar')
   })
   ;[
-    { status: StatusType.error, messageContext: {}, message: 'Reached max number of errors by minute: 1' },
-    { status: StatusType.warn, messageContext: {}, message: 'Reached max number of warns by minute: 1' },
-    { status: StatusType.info, messageContext: {}, message: 'Reached max number of infos by minute: 1' },
-    { status: StatusType.debug, messageContext: {}, message: 'Reached max number of debugs by minute: 1' },
-    {
-      status: StatusType.debug,
-      messageContext: { status: 'unknown' }, // overrides the rawLogsEvent status
-      message: 'Reached max number of customs by minute: 1',
-    },
-  ].forEach(({ status, message, messageContext }) => {
+    { status: StatusType.error, message: 'Reached max number of errors by minute: 1' },
+    { status: StatusType.warn, message: 'Reached max number of warns by minute: 1' },
+    { status: StatusType.info, message: 'Reached max number of infos by minute: 1' },
+    { status: StatusType.debug, message: 'Reached max number of debugs by minute: 1' },
+  ].forEach(({ status, message }) => {
     it(`stops sending ${status} logs when reaching the limit (message: "${message}")`, () => {
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'foo', status },
-        messageContext,
       })
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'bar', status },
-        messageContext,
       })
 
       expect(serverLogs.length).toEqual(1)
@@ -354,19 +325,15 @@ describe('logs limitation', () => {
 
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'discard me', status },
-        messageContext,
       })
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'discard me', status },
-        messageContext,
       })
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'discard me', status },
-        messageContext,
       })
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'foo', status },
-        messageContext,
       })
 
       expect(serverLogs.length).toEqual(1)
@@ -376,16 +343,13 @@ describe('logs limitation', () => {
     it(`allows to send new ${status}s after a minute (message: "${message}")`, () => {
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'foo', status },
-        messageContext,
       })
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'bar', status },
-        messageContext,
       })
       clock.tick(ONE_MINUTE)
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'baz', status },
-        messageContext,
       })
 
       expect(serverLogs.length).toEqual(2)
@@ -398,15 +362,12 @@ describe('logs limitation', () => {
       const otherLogStatus = status === StatusType.error ? StatusType.info : StatusType.error
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'foo', status },
-        messageContext,
       })
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'bar', status },
-        messageContext,
       })
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'baz', status: otherLogStatus },
-        ...{ ...messageContext, status: otherLogStatus },
       })
 
       expect(serverLogs.length).toEqual(2)
@@ -418,13 +379,11 @@ describe('logs limitation', () => {
 
   it('two different custom statuses are accounted by the same limit', () => {
     lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
-      rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'foo', status: StatusType.info },
-      messageContext: { status: 'foo' },
+      rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'foo', status: 'foo' as StatusType },
     })
 
     lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
-      rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'bar', status: StatusType.info },
-      messageContext: { status: 'bar' },
+      rawLogsEvent: { ...DEFAULT_MESSAGE, message: 'bar', status: 'bar' as StatusType },
     })
 
     expect(serverLogs.length).toEqual(1)

--- a/packages/browser-logs/src/domain/assembly.ts
+++ b/packages/browser-logs/src/domain/assembly.ts
@@ -27,7 +27,7 @@ export function startLogsAssembly(
 
   lifeCycle.subscribe(
     LifeCycleEventType.RAW_LOG_COLLECTED,
-    ({ rawLogsEvent, messageContext = undefined, savedCommonContext = undefined, domainContext, ddtags = [] }) => {
+    ({ rawLogsEvent, savedCommonContext = undefined, domainContext, ddtags = [] }) => {
       const startTime = toRelativeTime(rawLogsEvent.date)
       const commonContext = savedCommonContext || getCommonContext()
       const defaultLogsEventAttributes = hook.trigger({
@@ -46,7 +46,6 @@ export function startLogsAssembly(
         },
         defaultLogsEventAttributes,
         rawLogsEvent,
-        messageContext,
         {
           ddtags: defaultDdtags.concat(ddtags).join(','),
         }

--- a/packages/browser-logs/src/domain/console/consoleCollection.spec.ts
+++ b/packages/browser-logs/src/domain/console/consoleCollection.spec.ts
@@ -151,7 +151,7 @@ describe('console collection', () => {
       error: makeRawError({ context: { foo: 'bar' } }),
     })
 
-    expect(rawLogsEvents[0].messageContext).toEqual({ foo: 'bar' })
+    expect(rawLogsEvents[0].rawLogsEvent).toEqual(jasmine.objectContaining({ foo: 'bar' }))
   })
 })
 

--- a/packages/browser-logs/src/domain/console/consoleCollection.ts
+++ b/packages/browser-logs/src/domain/console/consoleCollection.ts
@@ -1,8 +1,8 @@
 import type { ClocksState } from '@datadog/js-core/time'
+import { combine, ConsoleApiName } from '@datadog/js-core/util'
 import type { Context, Observable, BufferedData } from '@datadog/browser-core'
 import { timeStampNow } from '@datadog/js-core/time'
 import { BufferedDataType, ErrorSource } from '@datadog/browser-core'
-import { ConsoleApiName } from '@datadog/js-core/util'
 import type { LogsConfiguration } from '../configuration'
 import type { LifeCycle, RawLogsEventCollectedData } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
@@ -35,15 +35,17 @@ export function startConsoleCollection(
       return
     }
     const collectedData: RawLogsEventCollectedData<RawLogsEvent> = {
-      rawLogsEvent: {
-        date: timeStampNow(),
-        message: log.message,
-        origin: ErrorSource.CONSOLE,
-        error: log.error && createErrorFieldFromRawError(log.error),
-        _dd: log.error && { debug_ids: log.error.debugIds },
-        status: LogStatusForApi[log.api],
-      },
-      messageContext: log.error?.context,
+      rawLogsEvent: combine(
+        {
+          date: timeStampNow(),
+          message: log.message,
+          origin: ErrorSource.CONSOLE,
+          error: log.error && createErrorFieldFromRawError(log.error),
+          _dd: log.error && { debug_ids: log.error.debugIds },
+          status: LogStatusForApi[log.api],
+        },
+        log.error?.context
+      ),
       domainContext: {
         handlingStack: log.handlingStack,
       },

--- a/packages/browser-logs/src/domain/lifeCycle.ts
+++ b/packages/browser-logs/src/domain/lifeCycle.ts
@@ -19,7 +19,6 @@ export type LifeCycle = AbstractLifeCycle<LifeCycleEventMap>
 
 export interface RawLogsEventCollectedData<E extends RawLogsEvent = RawLogsEvent> {
   rawLogsEvent: E
-  messageContext?: Context
   savedCommonContext?: CommonContext
   domainContext?: LogsEventDomainContext<E['origin']>
   ddtags?: string[]

--- a/packages/browser-logs/src/domain/logger/loggerCollection.spec.ts
+++ b/packages/browser-logs/src/domain/logger/loggerCollection.spec.ts
@@ -132,8 +132,6 @@ describe('logger collection', () => {
           message: 'message',
           status: StatusType.error,
           _dd: { debug_ids: undefined },
-        },
-        messageContext: {
           foo: 'from-logger',
           bar: 'from-message',
         },
@@ -143,6 +141,17 @@ describe('logger collection', () => {
         },
         ddtags: [],
       })
+    })
+
+    it('message context should take precedence over native raw log fields', () => {
+      handleLog(
+        { message: 'message', status: StatusType.error, context: { message: 'from-message-context' } },
+        logger,
+        HANDLING_STACK,
+        COMMON_CONTEXT
+      )
+
+      expect(rawLogsEvents[0].rawLogsEvent.message).toEqual('from-message-context')
     })
 
     it('should send the saved date when present', () => {

--- a/packages/browser-logs/src/domain/logger/loggerCollection.ts
+++ b/packages/browser-logs/src/domain/logger/loggerCollection.ts
@@ -26,14 +26,16 @@ export function startLoggerCollection(lifeCycle: LifeCycle) {
 
     if (isAuthorized(logsMessage.status, HandlerType.http, logger)) {
       const rawLogEventData: RawLogsEventCollectedData<RawLogsEvent> = {
-        rawLogsEvent: {
-          date: savedDate || timeStampNow(),
-          message: logsMessage.message,
-          status: logsMessage.status,
-          origin: ErrorSource.LOGGER,
-          _dd: { debug_ids: logsMessage.debugIds },
-        },
-        messageContext,
+        rawLogsEvent: combine(
+          {
+            date: savedDate || timeStampNow(),
+            message: logsMessage.message,
+            status: logsMessage.status,
+            origin: ErrorSource.LOGGER,
+            _dd: { debug_ids: logsMessage.debugIds },
+          },
+          messageContext
+        ),
         savedCommonContext,
         ddtags: logger.getTags(),
       }

--- a/packages/browser-logs/src/domain/runtimeError/runtimeErrorCollection.spec.ts
+++ b/packages/browser-logs/src/domain/runtimeError/runtimeErrorCollection.spec.ts
@@ -173,6 +173,6 @@ describe('runtime error collection', () => {
       },
     })
 
-    expect(rawLogsEvents[0].messageContext).toEqual({ foo: 'bar' })
+    expect(rawLogsEvents[0].rawLogsEvent).toEqual(jasmine.objectContaining({ foo: 'bar' }))
   })
 })

--- a/packages/browser-logs/src/domain/runtimeError/runtimeErrorCollection.ts
+++ b/packages/browser-logs/src/domain/runtimeError/runtimeErrorCollection.ts
@@ -1,4 +1,5 @@
 import type { ClocksState } from '@datadog/js-core/time'
+import { combine } from '@datadog/js-core/util'
 import type { Context, Observable, BufferedData } from '@datadog/browser-core'
 import { noop, ErrorSource, BufferedDataType } from '@datadog/browser-core'
 import type { LogsConfiguration } from '../configuration'
@@ -27,15 +28,17 @@ export function startRuntimeErrorCollection(
     if (bufferedData.type === BufferedDataType.RUNTIME_ERROR) {
       const error = bufferedData.data
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
-        rawLogsEvent: {
-          message: error.message,
-          date: error.startClocks.timeStamp,
-          error: createErrorFieldFromRawError(error),
-          _dd: { debug_ids: error.debugIds },
-          origin: ErrorSource.SOURCE,
-          status: StatusType.error,
-        },
-        messageContext: error.context,
+        rawLogsEvent: combine(
+          {
+            message: error.message,
+            date: error.startClocks.timeStamp,
+            error: createErrorFieldFromRawError(error),
+            _dd: { debug_ids: error.debugIds },
+            origin: ErrorSource.SOURCE,
+            status: StatusType.error,
+          },
+          error.context
+        ),
       })
     }
   })

--- a/packages/browser-logs/src/rawLogsEvent.types.ts
+++ b/packages/browser-logs/src/rawLogsEvent.types.ts
@@ -28,6 +28,7 @@ export interface CommonRawLogsEvent {
   _dd?: {
     debug_ids?: DebugIdEntry[]
   }
+  [key: string]: unknown
 }
 
 export interface RawConsoleLogsEvent extends CommonRawLogsEvent {


### PR DESCRIPTION
## Motivation

This is a small refactor that will simplify https://github.com/DataDog/browser-sdk/pull/4920 

Logs collection carried the user-provided message context as a separate `messageContext` field through the lifecycle, only to merge it into the event during assembly. This indirection added complexity to the data flow for no benefit, since the context is always meant to end up on the log event itself.

## Changes

- Merge `messageContext` directly into `rawLogsEvent` at collection time (console, logger, and runtime error sources) using `combine`, preserving the existing precedence (message context overrides base event fields).
- Remove the `messageContext` field from `RawLogsEventCollectedData`.
- Add an index signature to `CommonRawLogsEvent` so user context fields are accepted by the type system.
- Update affected specs and add a test asserting message context precedence over native raw log fields.

## Test instructions

- In the sandbox, send a log with extra context (e.g. `DD_LOGS.logger.log('hello', { foo: 'bar' })`) and confirm the context fields appear on the sent log event.
- Verify that passing a context key that collides with a native field (e.g. `message`) overrides the native value in the sent event.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
