### PR TITLE
📝 [Shopify] Update README to point to public docs instead of inline setup snippet

### DIFF
--- a/packages/browser-rum-shopify/README.md
+++ b/packages/browser-rum-shopify/README.md
@@ -2,35 +2,16 @@
 
 ## Overview
 
-This package bundles the RUM SDK together with a `shopifyPlugin` that translates Shopify Web
-Pixel events into RUM API calls, so Shopify's Custom Pixel sandbox only needs to load a single
-script.
+This package bundles the Datadog RUM Browser SDK together with a `shopifyPlugin` that translates
+Shopify Web Pixel events into RUM API calls, so a Shopify Custom Pixel only needs to load a
+single script.
 
-Exposes `window.DD_RUM`, same public API as [`@datadog/browser-rum`](../rum), plus
+Exposes `window.DD_RUM`, the same public API as [`@datadog/browser-rum`][2], plus
 `DD_RUM.shopifyPlugin(configuration)`.
 
-## Setup
+See the [dedicated Datadog documentation][1] for the installation process.
 
-In a Custom Pixel, pass the sandbox's `analytics` global to the plugin:
+<!-- Note: all URLs should be absolute -->
 
-```javascript
-DD_RUM.onReady(function () {
-  DD_RUM.init({
-    applicationId: '<YOUR_DATADOG_APPLICATION_ID>',
-    clientToken: '<YOUR_DATADOG_CLIENT_TOKEN>',
-    site: '<YOUR_DATADOG_SITE>',
-    service: '<YOUR_SERVICE_NAME>',
-    env: '<YOUR_ENV_NAME>',
-    version: '1.0.0',
-    sessionSampleRate: 100,
-    plugins: [DD_RUM.shopifyPlugin({ shopifyAnalytics: analytics })],
-  })
-})
-```
-
-The plugin patches sandboxed iframe APIs, wires Shopify Web Pixel events to the RUM public API,
-and forces configuration suited to the Pixel sandbox (e.g. `trackViewsManually: true`,
-`sessionReplaySampleRate: 0`).
-
-On storefront pages (outside the Pixel sandbox), don't include the plugin — see the
-[RUM package](../rum/README.md) documentation for `init()` options.
+[1]: https://docs.datadoghq.com/integrations/rum-shopify
+[2]: https://www.npmjs.com/package/@datadog/browser-rum


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

[RUM-17751](https://datadoghq.atlassian.net/browse/RUM-17751): the `browser-rum-shopify` README duplicated setup instructions (an inline `init()` snippet with the `shopifyPlugin` config) that are also covered by the public Datadog documentation. Keeping the same content in two places means the README silently goes stale whenever the public docs are updated. This reduces the number of surfaces we need to keep in sync by pointing to the public docs instead.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

- Trimmed `packages/browser-rum-shopify/README.md` to a short overview of the package plus a link to the [dedicated Datadog documentation][1] for the installation process, dropping the inline `init()`/`shopifyPlugin(...)` code example.
- No code or behavior changes — documentation only.

[1]: https://docs.datadoghq.com/real_user_monitoring/browser

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

Documentation-only change — reviewed by reading the rendered README on GitHub.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->


[RUM-17751]: https://datadoghq.atlassian.net/browse/RUM-17751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ