### PR TITLE
👷 [Shopify] Add Slack notification on e2e-shopify-scheduled failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -658,6 +658,18 @@ e2e-shopify-scheduled:
   after_script:
     - node ./scripts/test/export-test-result.ts e2e
 
+e2e-shopify-scheduled-failure:
+  extends: .prepare_notification
+  only:
+    variables:
+      - $TARGET_TASK_NAME == "e2e-shopify-scheduled"
+  when: on_failure
+  script:
+    - 'MESSAGE_TEXT=":fire: [*$CI_PROJECT_NAME*] <$BUILD_URL|Shopify e2e tests failed> :fire:"'
+    - postmessage "#rum-browser-sdk-ops" "$MESSAGE_TEXT"
+  dependencies:
+    - e2e-shopify-scheduled
+
 ########################################################################################################################
 # Check expired telemetry
 ########################################################################################################################


### PR DESCRIPTION
## Motivation

[RUM-18250](https://datadoghq.atlassian.net/browse/RUM-18250): the `e2e-shopify-scheduled` GitLab pipeline had no failure notification, unlike other scheduled task pipelines (e.g. `check-expired-telemetry-scheduled`), so a failing Shopify e2e run against the live dev store could go unnoticed.

## Changes

- Added `e2e-shopify-scheduled-failure` job to `.gitlab-ci.yml`, following the same `.prepare_notification` + `dependencies` + `when: on_failure` pattern used by `check-expired-telemetry-scheduled-failure`.
- Posts to `#rum-browser-sdk-ops` via the shared `postmessage` helper when `e2e-shopify-scheduled` fails.

## Test instructions

CI-config-only change; no unit tests apply. Verified the YAML parses correctly and matches Prettier formatting (`npx prettier --check .gitlab-ci.yml`). To fully verify the notification fires, trigger the `e2e-shopify-scheduled` scheduled pipeline on GitLab with a failing condition and confirm a message lands in `#rum-browser-sdk-ops`.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file


[RUM-18250]: https://datadoghq.atlassian.net/browse/RUM-18250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ