### PR TITLE
🐛 Prefer anchor and role="link" text over ancestor ARIA labels for RUM action names

### DIFF
--- a/packages/browser-rum-core/src/domain/action/getActionNameFromElement.spec.ts
+++ b/packages/browser-rum-core/src/domain/action/getActionNameFromElement.spec.ts
@@ -272,6 +272,47 @@ describe('getActionNameFromElement', () => {
     expect(nameSource).toBe('text_content')
   })
 
+  it('extracts text from an A element', () => {
+    const { name, nameSource } = getActionNameFromElement(
+      appendElement(`
+      <div>
+        <div>ignored</div>
+        <a href="/x" target>foo</a>
+      </div>
+    `),
+      defaultConfiguration
+    )
+    expect(name).toBe('foo')
+    expect(nameSource).toBe('text_content')
+  })
+
+  it('extracts text from a role=link element', () => {
+    const { name, nameSource } = getActionNameFromElement(
+      appendElement(`
+      <div>
+        <div>ignored</div>
+        <span role="link" target>foo</span>
+      </div>
+    `),
+      defaultConfiguration
+    )
+    expect(name).toBe('foo')
+    expect(nameSource).toBe('text_content')
+  })
+
+  it('prefers an anchor text over an ancestor aria-label', () => {
+    const { name, nameSource } = getActionNameFromElement(
+      appendElement(`
+      <div aria-label="ignored">
+        <a href="/x" target>foo</a>
+      </div>
+    `),
+      defaultConfiguration
+    )
+    expect(name).toBe('foo')
+    expect(nameSource).toBe('text_content')
+  })
+
   it('limits the recursion to the 10th parent', () => {
     const { name, nameSource } = getActionNameFromElement(
       appendElement(`

--- a/packages/browser-rum-core/src/domain/action/getActionNameFromElement.ts
+++ b/packages/browser-rum-core/src/domain/action/getActionNameFromElement.ts
@@ -92,9 +92,15 @@ const priorityStrategies: NameStrategy[] = [
       }
     }
   },
-  // BUTTON, LABEL or button-like element text
+  // BUTTON, LABEL, A or button/link-like element text
   (element, rumConfiguration, nodePrivacyLevelCache) => {
-    if (element.nodeName === 'BUTTON' || element.nodeName === 'LABEL' || element.getAttribute('role') === 'button') {
+    if (
+      element.nodeName === 'BUTTON' ||
+      element.nodeName === 'LABEL' ||
+      element.nodeName === 'A' ||
+      element.getAttribute('role') === 'button' ||
+      element.getAttribute('role') === 'link'
+    ) {
       return getActionNameFromTextualContent(element, rumConfiguration, nodePrivacyLevelCache)
     }
   },


### PR DESCRIPTION
## Motivation

Addresses bug report https://github.com/DataDog/browser-sdk/issues/5007

`getActionNameFromElement` runs every `priorityStrategies` entry against the target and up to 10 ancestors before ever falling back to text content of the target. When an anchor sits inside an ancestor with an `aria-label` or `aria-labelledby` (for example a `role="dialog"` whose `aria-labelledby` points at a visually-hidden title), RUM records the ancestor's label as the action name instead of the visible anchor text the user actually clicked.

This is common with accessible dialog primitives that require a title element on the dialog root, and it produces surprising click names like `click on This is a modal window` on every anchor inside the modal.

## Changes

The [("BUTTON, LABEL or button-like element text") priority strategy](https://github.com/DataDog/browser-sdk/blob/c00a5cf8c7e601b3025dc6b710a3962c5bb9d5aa/packages/browser-rum-core/src/domain/action/getActionNameFromElement.ts#L95-L100) now also matches `<a>` and `role="link"`, mirroring the existing symmetry with `<button>` and `role="button"`. The text content of the clicked anchor is picked at iteration 0 of the walk, so ancestor ARIA attributes no longer beat it.

**Behavior change to flag:** an `<a>` (or `role="link"`) that carries **both** a visible text label and its own `aria-label` will now resolve to the visible text instead of the `aria-label`. That matches how `<button>` has always worked, but any team relying on the previous behavior will see a name shift. Not gated behind a config flag but happy to do so if desired.

## Test instructions

```
yarn test:unit --spec packages/browser-rum-core/src/domain/action/getActionNameFromElement.spec.ts
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file