### PR TITLE
👷 Use workspace:* protocol for internal monorepo dependencies

### DIFF
--- a/packages/browser-core/package.json
+++ b/packages/browser-core/package.json
@@ -23,7 +23,7 @@
     "directory": "packages/browser-core"
   },
   "dependencies": {
-    "@datadog/js-core": "0.0.13"
+    "@datadog/js-core": "workspace:*"
   },
   "devDependencies": {
     "pako": "3.0.1"

--- a/packages/browser-debugger/package.json
+++ b/packages/browser-debugger/package.json
@@ -22,8 +22,8 @@
     "acorn": "8.18.0"
   },
   "dependencies": {
-    "@datadog/browser-core": "7.12.0",
-    "@datadog/js-core": "0.0.13"
+    "@datadog/browser-core": "workspace:*",
+    "@datadog/js-core": "workspace:*"
   },
   "repository": {
     "type": "git",

--- a/packages/browser-logs/package.json
+++ b/packages/browser-logs/package.json
@@ -19,11 +19,11 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "7.12.0",
-    "@datadog/js-core": "0.0.13"
+    "@datadog/browser-core": "workspace:*",
+    "@datadog/js-core": "workspace:*"
   },
   "peerDependencies": {
-    "@datadog/browser-rum": "7.12.0"
+    "@datadog/browser-rum": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@datadog/browser-rum": {

--- a/packages/browser-rum-angular/package.json
+++ b/packages/browser-rum-angular/package.json
@@ -17,9 +17,9 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@datadog/browser-core": "7.12.0",
-    "@datadog/browser-rum-core": "7.12.0",
-    "@datadog/js-core": "0.0.13"
+    "@datadog/browser-core": "workspace:*",
+    "@datadog/browser-rum-core": "workspace:*",
+    "@datadog/js-core": "workspace:*"
   },
   "peerDependencies": {
     "@angular/core": ">=15 <=22",

--- a/packages/browser-rum-core/package.json
+++ b/packages/browser-rum-core/package.json
@@ -17,8 +17,8 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "7.12.0",
-    "@datadog/js-core": "0.0.13"
+    "@datadog/browser-core": "workspace:*",
+    "@datadog/js-core": "workspace:*"
   },
   "devDependencies": {
     "ajv": "8.20.0"

--- a/packages/browser-rum-nextjs/package.json
+++ b/packages/browser-rum-nextjs/package.json
@@ -17,10 +17,10 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "7.12.0",
-    "@datadog/browser-rum-core": "7.12.0",
-    "@datadog/browser-rum-react": "7.12.0",
-    "@datadog/js-core": "0.0.13"
+    "@datadog/browser-core": "workspace:*",
+    "@datadog/browser-rum-core": "workspace:*",
+    "@datadog/browser-rum-react": "workspace:*",
+    "@datadog/js-core": "workspace:*"
   },
   "peerDependencies": {
     "next": ">=13.0.0",

--- a/packages/browser-rum-nuxt/package.json
+++ b/packages/browser-rum-nuxt/package.json
@@ -17,9 +17,9 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "7.12.0",
-    "@datadog/browser-rum-core": "7.12.0",
-    "@datadog/js-core": "0.0.13"
+    "@datadog/browser-core": "workspace:*",
+    "@datadog/browser-rum-core": "workspace:*",
+    "@datadog/js-core": "workspace:*"
   },
   "peerDependencies": {
     "nuxt": "3 || 4",

--- a/packages/browser-rum-react/package.json
+++ b/packages/browser-rum-react/package.json
@@ -23,9 +23,9 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "7.12.0",
-    "@datadog/browser-rum-core": "7.12.0",
-    "@datadog/js-core": "0.0.13"
+    "@datadog/browser-core": "workspace:*",
+    "@datadog/browser-rum-core": "workspace:*",
+    "@datadog/js-core": "workspace:*"
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.64.0 <2",

--- a/packages/browser-rum-shopify/package.json
+++ b/packages/browser-rum-shopify/package.json
@@ -19,10 +19,10 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "7.12.0",
-    "@datadog/browser-rum": "7.12.0",
-    "@datadog/browser-rum-core": "7.12.0",
-    "@datadog/js-core": "0.0.13"
+    "@datadog/browser-core": "workspace:*",
+    "@datadog/browser-rum": "workspace:*",
+    "@datadog/browser-rum-core": "workspace:*",
+    "@datadog/js-core": "workspace:*"
   },
   "repository": {
     "type": "git",

--- a/packages/browser-rum-slim/package.json
+++ b/packages/browser-rum-slim/package.json
@@ -19,12 +19,12 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "7.12.0",
-    "@datadog/browser-rum-core": "7.12.0",
-    "@datadog/js-core": "0.0.13"
+    "@datadog/browser-core": "workspace:*",
+    "@datadog/browser-rum-core": "workspace:*",
+    "@datadog/js-core": "workspace:*"
   },
   "peerDependencies": {
-    "@datadog/browser-logs": "7.12.0"
+    "@datadog/browser-logs": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@datadog/browser-logs": {

--- a/packages/browser-rum-vue/package.json
+++ b/packages/browser-rum-vue/package.json
@@ -19,9 +19,9 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "7.12.0",
-    "@datadog/browser-rum-core": "7.12.0",
-    "@datadog/js-core": "0.0.13"
+    "@datadog/browser-core": "workspace:*",
+    "@datadog/browser-rum-core": "workspace:*",
+    "@datadog/js-core": "workspace:*"
   },
   "peerDependencies": {
     "vue": "^3.5.0",

--- a/packages/browser-rum/package.json
+++ b/packages/browser-rum/package.json
@@ -21,12 +21,12 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "7.12.0",
-    "@datadog/browser-rum-core": "7.12.0",
-    "@datadog/js-core": "0.0.13"
+    "@datadog/browser-core": "workspace:*",
+    "@datadog/browser-rum-core": "workspace:*",
+    "@datadog/js-core": "workspace:*"
   },
   "peerDependencies": {
-    "@datadog/browser-logs": "7.12.0"
+    "@datadog/browser-logs": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@datadog/browser-logs": {
@@ -39,7 +39,7 @@
     "directory": "packages/browser-rum"
   },
   "devDependencies": {
-    "@datadog/browser-worker": "7.12.0",
+    "@datadog/browser-worker": "workspace:*",
     "pako": "3.0.1"
   },
   "volta": {

--- a/packages/browser-worker/package.json
+++ b/packages/browser-worker/package.json
@@ -15,7 +15,7 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "7.12.0"
+    "@datadog/browser-core": "workspace:*"
   },
   "repository": {
     "type": "git",

--- a/scripts/lib/checkBrowserSdkPackageJsonFiles.ts
+++ b/scripts/lib/checkBrowserSdkPackageJsonFiles.ts
@@ -17,18 +17,9 @@ export function checkPackageJsonFiles(): void {
 `
   )
 
-  // Map each independently-versioned package (e.g. @datadog/js-core) to its own version, so we can
-  // check that dependents reference the matching version rather than the synced release version.
-  const independentVersions = new Map<string, string>()
-  for (const { content } of packageJsonFiles) {
-    if (content.name && isIndependentlyVersionedPackage(content.name) && content.version) {
-      independentVersions.set(content.name, content.version)
-    }
-  }
-
   for (const packageJsonFile of packageJsonFiles) {
     checkPackageJsonVersion(packageJsonFile)
-    checkPackageDependencyVersions(packageJsonFile, independentVersions)
+    checkPackageDependencyVersions(packageJsonFile)
   }
 }
 function checkPackageJsonVersion(packageJsonInfo: PackageJsonInfo): void {
@@ -55,10 +46,7 @@ function checkPackageJsonVersion(packageJsonInfo: PackageJsonInfo): void {
     )
   }
 }
-function checkPackageDependencyVersions(
-  packageJsonInfo: PackageJsonInfo,
-  independentVersions: Map<string, string>
-): void {
+function checkPackageDependencyVersions(packageJsonInfo: PackageJsonInfo): void {
   if (packageJsonInfo.content.private) {
     return
   }
@@ -73,18 +61,12 @@ function checkPackageDependencyVersions(
     }
 
     for (const [dependencyName, dependencyVersion] of Object.entries(dependencies)) {
-      // Independently-versioned packages (e.g. @datadog/js-core) are pinned to their own version,
-      // so dependents must reference that version rather than the synced release version.
-      const expectedIndependentVersion = independentVersions.get(dependencyName)
-      if (expectedIndependentVersion !== undefined) {
-        if (dependencyVersion !== expectedIndependentVersion) {
-          throw new Error(
-            `Invalid dependency version for ${dependencyName} in ${packageJsonInfo.relativePath}: expected ${expectedIndependentVersion}, got ${dependencyVersion}`
-          )
-        }
-      } else if (isBrowserSdkPackageName(dependencyName) && dependencyVersion !== releaseVersion) {
+      // Internal Browser SDK packages are resolved from the monorepo workspaces, so dependents must
+      // reference them with the `workspace:` protocol instead of a hardcoded version. Yarn rewrites
+      // `workspace:*` to the resolved concrete version at publish time.
+      if (isBrowserSdkPackageName(dependencyName) && dependencyVersion !== 'workspace:*') {
         throw new Error(
-          `Invalid dependency version for ${dependencyName} in ${packageJsonInfo.relativePath}: expected ${releaseVersion}, got ${dependencyVersion}`
+          `Invalid dependency version for ${dependencyName} in ${packageJsonInfo.relativePath}: expected workspace:*, got ${dependencyVersion}`
         )
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -454,11 +454,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/browser-core@npm:7.12.0, @datadog/browser-core@workspace:*, @datadog/browser-core@workspace:packages/browser-core":
+"@datadog/browser-core@workspace:*, @datadog/browser-core@workspace:packages/browser-core":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-core@workspace:packages/browser-core"
   dependencies:
-    "@datadog/js-core": "npm:0.0.13"
+    "@datadog/js-core": "workspace:*"
     pako: "npm:3.0.1"
   languageName: unknown
   linkType: soft
@@ -467,8 +467,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-debugger@workspace:packages/browser-debugger"
   dependencies:
-    "@datadog/browser-core": "npm:7.12.0"
-    "@datadog/js-core": "npm:0.0.13"
+    "@datadog/browser-core": "workspace:*"
+    "@datadog/js-core": "workspace:*"
     acorn: "npm:8.18.0"
   languageName: unknown
   linkType: soft
@@ -477,10 +477,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-logs@workspace:packages/browser-logs"
   dependencies:
-    "@datadog/browser-core": "npm:7.12.0"
-    "@datadog/js-core": "npm:0.0.13"
+    "@datadog/browser-core": "workspace:*"
+    "@datadog/js-core": "workspace:*"
   peerDependencies:
-    "@datadog/browser-rum": 7.12.0
+    "@datadog/browser-rum": "workspace:*"
   peerDependenciesMeta:
     "@datadog/browser-rum":
       optional: true
@@ -496,9 +496,9 @@ __metadata:
     "@angular/core": "npm:22.1.2"
     "@angular/platform-browser": "npm:22.1.2"
     "@angular/router": "npm:22.1.2"
-    "@datadog/browser-core": "npm:7.12.0"
-    "@datadog/browser-rum-core": "npm:7.12.0"
-    "@datadog/js-core": "npm:0.0.13"
+    "@datadog/browser-core": "workspace:*"
+    "@datadog/browser-rum-core": "workspace:*"
+    "@datadog/js-core": "workspace:*"
     rxjs: "npm:7.8.2"
   peerDependencies:
     "@angular/core": ">=15 <=22"
@@ -507,12 +507,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/browser-rum-core@npm:7.12.0, @datadog/browser-rum-core@workspace:*, @datadog/browser-rum-core@workspace:packages/browser-rum-core":
+"@datadog/browser-rum-core@workspace:*, @datadog/browser-rum-core@workspace:packages/browser-rum-core":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-core@workspace:packages/browser-rum-core"
   dependencies:
-    "@datadog/browser-core": "npm:7.12.0"
-    "@datadog/js-core": "npm:0.0.13"
+    "@datadog/browser-core": "workspace:*"
+    "@datadog/js-core": "workspace:*"
     ajv: "npm:8.20.0"
   languageName: unknown
   linkType: soft
@@ -521,10 +521,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-nextjs@workspace:packages/browser-rum-nextjs"
   dependencies:
-    "@datadog/browser-core": "npm:7.12.0"
-    "@datadog/browser-rum-core": "npm:7.12.0"
-    "@datadog/browser-rum-react": "npm:7.12.0"
-    "@datadog/js-core": "npm:0.0.13"
+    "@datadog/browser-core": "workspace:*"
+    "@datadog/browser-rum-core": "workspace:*"
+    "@datadog/browser-rum-react": "workspace:*"
+    "@datadog/js-core": "workspace:*"
     "@types/react": "npm:19.2.18"
     next: "npm:16.3.1"
     react: "npm:19.2.8"
@@ -544,9 +544,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-nuxt@workspace:packages/browser-rum-nuxt"
   dependencies:
-    "@datadog/browser-core": "npm:7.12.0"
-    "@datadog/browser-rum-core": "npm:7.12.0"
-    "@datadog/js-core": "npm:0.0.13"
+    "@datadog/browser-core": "workspace:*"
+    "@datadog/browser-rum-core": "workspace:*"
+    "@datadog/js-core": "workspace:*"
     vue: "npm:3.5.41"
     vue-router: "npm:5.2.0"
   peerDependencies:
@@ -567,13 +567,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/browser-rum-react@npm:7.12.0, @datadog/browser-rum-react@workspace:packages/browser-rum-react":
+"@datadog/browser-rum-react@workspace:*, @datadog/browser-rum-react@workspace:packages/browser-rum-react":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-react@workspace:packages/browser-rum-react"
   dependencies:
-    "@datadog/browser-core": "npm:7.12.0"
-    "@datadog/browser-rum-core": "npm:7.12.0"
-    "@datadog/js-core": "npm:0.0.13"
+    "@datadog/browser-core": "workspace:*"
+    "@datadog/browser-rum-core": "workspace:*"
+    "@datadog/js-core": "workspace:*"
     "@tanstack/react-router": "npm:1.170.30"
     "@types/react": "npm:19.2.18"
     "@types/react-dom": "npm:19.2.4"
@@ -607,10 +607,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-shopify@workspace:packages/browser-rum-shopify"
   dependencies:
-    "@datadog/browser-core": "npm:7.12.0"
-    "@datadog/browser-rum": "npm:7.12.0"
-    "@datadog/browser-rum-core": "npm:7.12.0"
-    "@datadog/js-core": "npm:0.0.13"
+    "@datadog/browser-core": "workspace:*"
+    "@datadog/browser-rum": "workspace:*"
+    "@datadog/browser-rum-core": "workspace:*"
+    "@datadog/js-core": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -618,11 +618,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-slim@workspace:packages/browser-rum-slim"
   dependencies:
-    "@datadog/browser-core": "npm:7.12.0"
-    "@datadog/browser-rum-core": "npm:7.12.0"
-    "@datadog/js-core": "npm:0.0.13"
+    "@datadog/browser-core": "workspace:*"
+    "@datadog/browser-rum-core": "workspace:*"
+    "@datadog/js-core": "workspace:*"
   peerDependencies:
-    "@datadog/browser-logs": 7.12.0
+    "@datadog/browser-logs": "workspace:*"
   peerDependenciesMeta:
     "@datadog/browser-logs":
       optional: true
@@ -633,9 +633,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-vue@workspace:packages/browser-rum-vue"
   dependencies:
-    "@datadog/browser-core": "npm:7.12.0"
-    "@datadog/browser-rum-core": "npm:7.12.0"
-    "@datadog/js-core": "npm:0.0.13"
+    "@datadog/browser-core": "workspace:*"
+    "@datadog/browser-rum-core": "workspace:*"
+    "@datadog/js-core": "workspace:*"
     "@vue/compiler-dom": "npm:3.5.41"
     "@vue/test-utils": "npm:2.4.11"
     vue: "npm:3.5.41"
@@ -655,17 +655,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/browser-rum@npm:7.12.0, @datadog/browser-rum@workspace:*, @datadog/browser-rum@workspace:packages/browser-rum":
+"@datadog/browser-rum@workspace:*, @datadog/browser-rum@workspace:packages/browser-rum":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum@workspace:packages/browser-rum"
   dependencies:
-    "@datadog/browser-core": "npm:7.12.0"
-    "@datadog/browser-rum-core": "npm:7.12.0"
-    "@datadog/browser-worker": "npm:7.12.0"
-    "@datadog/js-core": "npm:0.0.13"
+    "@datadog/browser-core": "workspace:*"
+    "@datadog/browser-rum-core": "workspace:*"
+    "@datadog/browser-worker": "workspace:*"
+    "@datadog/js-core": "workspace:*"
     pako: "npm:3.0.1"
   peerDependencies:
-    "@datadog/browser-logs": 7.12.0
+    "@datadog/browser-logs": "workspace:*"
   peerDependenciesMeta:
     "@datadog/browser-logs":
       optional: true
@@ -697,16 +697,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/browser-worker@npm:7.12.0, @datadog/browser-worker@workspace:packages/browser-worker":
+"@datadog/browser-worker@workspace:*, @datadog/browser-worker@workspace:packages/browser-worker":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-worker@workspace:packages/browser-worker"
   dependencies:
-    "@datadog/browser-core": "npm:7.12.0"
+    "@datadog/browser-core": "workspace:*"
     webpack: "npm:5.109.2"
   languageName: unknown
   linkType: soft
 
-"@datadog/js-core@npm:0.0.13, @datadog/js-core@workspace:*, @datadog/js-core@workspace:packages/js-core":
+"@datadog/js-core@workspace:*, @datadog/js-core@workspace:packages/js-core":
   version: 0.0.0-use.local
   resolution: "@datadog/js-core@workspace:packages/js-core"
   languageName: unknown


### PR DESCRIPTION
## Motivation

Internal `@datadog` dependencies were hardcoded to the exact release version (e.g. `7.11.0`, `0.0.12`) in every `package.json`. This requires updating all of them on each release and causes avoidable merge conflicts on release branches.

## Changes

- Switched all internal `@datadog/*` dependencies in `packages/*/package.json` (dependencies, devDependencies, and peerDependencies) from hardcoded versions to Yarn's `workspace:*` protocol.
- Updated the `checkBrowserSdkPackageJsonFiles` CI check to assert internal dependencies use `workspace:*` instead of matching a concrete version, and removed the now-unneeded `independentVersions` map (js-core is now also referenced via `workspace:*`).
- Regenerated `yarn.lock` (registry resolutions replaced by pure workspace references).

`workspace:*` resolves to the local package version at install time and is rewritten to the concrete version when publishing to npm (`yarn workspaces foreach ... npm publish` in `publish-npm.ts`), so published artifacts are unaffected.

## Test instructions

- Run `yarn install` and confirm it resolves cleanly from workspaces.
- Run `yarn typecheck`.
- Verify with `yarn pack --dry-run` on a package (e.g. `packages/browser-rum`) that the packed `package.json` shows concrete versions, not `workspace:*`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
