### PR TITLE
👷 Sync rum-events-format schemas for session replay image content

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "woke": "scripts/cli woke"
   },
   "devDependencies": {
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=c6b13a3e00dd323c48240bacb6d8e7699b4e8b7f",
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=3eb091af81e4c1a563bcd335222fed86f5bc8bc7",
     "@eslint/js": "10.0.1",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@microsoft/api-extractor": "7.58.12",

--- a/packages/browser-rum-core/src/rumEvent.types.ts
+++ b/packages/browser-rum-core/src/rumEvent.types.ts
@@ -309,6 +309,7 @@ export type RumErrorEvent = CommonProperties &
       readonly source_type?:
         | 'android'
         | 'browser'
+        | 'browser+wasm'
         | 'ios'
         | 'react-native'
         | 'flutter'
@@ -422,6 +423,20 @@ export type RumErrorEvent = CommonProperties &
          * CPU architecture from the library.
          */
         readonly arch?: string
+        [k: string]: unknown
+      }[]
+      /**
+       * WebAssembly modules available for stack trace symbolication.
+       */
+      readonly wasm_modules?: {
+        /**
+         * URL identifying the WebAssembly module.
+         */
+        readonly url: string
+        /**
+         * Build ID used to identify the WebAssembly debug symbols.
+         */
+        readonly build_id: string
         [k: string]: unknown
       }[]
       /**

--- a/packages/browser-rum/src/domain/record/encoding/changeDecoder.spec.ts
+++ b/packages/browser-rum/src/domain/record/encoding/changeDecoder.spec.ts
@@ -22,6 +22,19 @@ describe('ChangeDecoder', () => {
     expect(decoded.data).toEqual([[ChangeType.Text, [0, 'Hello World']]])
   })
 
+  it('decodes an image content resource ID string table reference', () => {
+    const decoder = createChangeDecoder()
+
+    const decoded = decoder.decode(
+      changeRecord(
+        [ChangeType.AddRoleAnnotatedStrings, [StringRole.ResourceId, 'resource-id']],
+        [ChangeType.ImageContent, [42, 0]]
+      )
+    )
+
+    expect(decoded.data).toEqual([[ChangeType.ImageContent, [42, 'resource-id']]])
+  })
+
   describe('clearing the string table', () => {
     it('interprets the references that follow a clear against an emptied string table', () => {
       const decoder = createChangeDecoder()

--- a/packages/browser-rum/src/domain/record/encoding/changeDecoder.ts
+++ b/packages/browser-rum/src/domain/record/encoding/changeDecoder.ts
@@ -14,6 +14,7 @@ import type {
   InputValueChange,
   StyleSheetRules,
   TextChange,
+  ImageContentChange,
 } from '../../../types'
 import type { StringTable } from './stringTable'
 import { createStringTable } from './stringTable'
@@ -171,6 +172,16 @@ function decodeChangeRecord(
         const decoded: [typeof ChangeType.AddStyleSheet, ...AddStyleSheetChange[]] = [ChangeType.AddStyleSheet]
         for (let i = 1; i < change.length; i++) {
           decoded.push(decodeAddStyleSheetChange(change[i] as AddStyleSheetChange, stringTable))
+        }
+        decodedData.push(decoded)
+        break
+      }
+
+      case ChangeType.ImageContent: {
+        const decoded: [typeof ChangeType.ImageContent, ...ImageContentChange[]] = [ChangeType.ImageContent]
+        for (let i = 1; i < change.length; i++) {
+          const imageContentChange = change[i] as ImageContentChange
+          decoded.push([imageContentChange[0], stringTable.decodeAnnotated(imageContentChange[1])])
         }
         decodedData.push(decoded)
         break

--- a/packages/browser-rum/src/domain/record/encoding/changeEncoder.ts
+++ b/packages/browser-rum/src/domain/record/encoding/changeEncoder.ts
@@ -280,6 +280,7 @@ function createRunChangeEncoder(stringIds: StringIds): RunChangeEncoder {
       ChangeType.AttachedStyleSheets,
       ChangeType.MediaPlaybackState,
       ChangeType.VisualViewport,
+      ChangeType.ImageContent,
     ].forEach((changeType: ChangeType): void => {
       const change = pendingChanges[changeType]
       if (change) {

--- a/packages/browser-rum/src/domain/record/encoding/stringIds.ts
+++ b/packages/browser-rum/src/domain/record/encoding/stringIds.ts
@@ -61,6 +61,7 @@ function createMapsByRole(): StringIdMapsByRole {
     [StringRole.FormInput]: createStringIdMap(),
     [StringRole.Css]: createStringIdMap(),
     [StringRole.Url]: createStringIdMap(),
+    [StringRole.ResourceId]: createStringIdMap(),
   }
 }
 

--- a/packages/browser-rum/src/types/sessionReplay.ts
+++ b/packages/browser-rum/src/types/sessionReplay.ts
@@ -117,6 +117,7 @@ export type Change =
   | [12, ...InputValueChange[]]
   | [13, ...InputSelectionChange[]]
   | [14]
+  | [15, ...ImageContentChange[]]
 /**
  * Browser-specific. Schema representing the addition of a string to the string table, annotated as belonging to the default string role.
  */
@@ -198,6 +199,7 @@ export type StringRoleId =
   | StringRoleFormInput
   | StringRoleCSS
   | StringRoleURL
+  | StringResourceId
 /**
  * The default string role, used for uncategorized strings. Strings added by an AddStringChange are added to this string role.
  */
@@ -230,6 +232,10 @@ export type StringRoleCSS = 6
  * A string role containing URLs.
  */
 export type StringRoleURL = 7
+/**
+ * A string role containing resource IDs.
+ */
+export type StringResourceId = 8
 /**
  * Schema representing the addition of a new #document node.
  *
@@ -436,6 +442,12 @@ export type InputSelectionStateDeselected = 1
  * The element is neither selected nor deselected. This state only applies to checkboxes, which render it distinctly from both the selected and deselected states.
  */
 export type InputSelectionStateIndeterminate = 2
+/**
+ * Browser-specific. Schema representing a change in an element's image content, identified by a resource ID.
+ *
+ * @minItems 2
+ */
+export type ImageContentChange = [NodeId, StringOrStringReference]
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */

--- a/packages/browser-rum/src/types/sessionReplayConstants.ts
+++ b/packages/browser-rum/src/types/sessionReplayConstants.ts
@@ -63,6 +63,7 @@ export const ChangeType: {
   InputValue: ChangeTypeId<12, SessionReplay.InputValueChange>
   InputSelection: ChangeTypeId<13, SessionReplay.InputSelectionChange>
   ClearStrings: DatalessChangeTypeId<14>
+  ImageContent: ChangeTypeId<15, SessionReplay.ImageContentChange>
 } = {
   AddString: 0,
   AddNode: 1,
@@ -79,6 +80,7 @@ export const ChangeType: {
   InputValue: 12,
   InputSelection: 13,
   ClearStrings: 14,
+  ImageContent: 15,
 } as const
 
 export type ChangeType = (typeof ChangeType)[keyof typeof ChangeType]
@@ -97,6 +99,7 @@ export const StringRole: {
   FormInput: SessionReplay.StringRoleFormInput
   Css: SessionReplay.StringRoleCSS
   Url: SessionReplay.StringRoleURL
+  ResourceId: SessionReplay.StringResourceId
 } = {
   Default: 0,
   NodeName: 1,
@@ -106,6 +109,7 @@ export const StringRole: {
   FormInput: 5,
   Css: 6,
   Url: 7,
+  ResourceId: 8,
 } as const
 
 export type StringRole = (typeof StringRole)[keyof typeof StringRole]

--- a/yarn.lock
+++ b/yarn.lock
@@ -712,10 +712,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/rum-events-format@DataDog/rum-events-format#commit=c6b13a3e00dd323c48240bacb6d8e7699b4e8b7f":
+"@datadog/rum-events-format@DataDog/rum-events-format#commit=3eb091af81e4c1a563bcd335222fed86f5bc8bc7":
   version: 0.0.0
-  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=c6b13a3e00dd323c48240bacb6d8e7699b4e8b7f"
-  checksum: 10c0/01f36a55946b1d9267cc24dcf1a7eba2faad1666ec22cbf997d5ea6bfd1e2f85d97c42d5628005bfd095fa49950dc5a27ed3b666dda3ed567c4ee5f2aa4af803
+  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=3eb091af81e4c1a563bcd335222fed86f5bc8bc7"
+  checksum: 10c0/0e15dd8544b13b6dbb9e32b3242db3766afd343c7632bac6cad24d8a89a25af3cf1cd3dd1490477543ca92167b78426b8bdf057e16fac0c7890bf9d7f9e4375e
   languageName: node
   linkType: hard
 
@@ -6098,7 +6098,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "browser-sdk@workspace:."
   dependencies:
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=c6b13a3e00dd323c48240bacb6d8e7699b4e8b7f"
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=3eb091af81e4c1a563bcd335222fed86f5bc8bc7"
     "@eslint/js": "npm:10.0.1"
     "@jsdevtools/coverage-istanbul-loader": "npm:3.0.5"
     "@microsoft/api-extractor": "npm:7.58.12"


### PR DESCRIPTION
## Motivation

Synchronize the Browser SDK with the latest `rum-events-format` schema so session replay can represent image content changes and resource IDs consistently.

## Changes

- Bump `@datadog/rum-events-format` to the schema revision containing:
  - `ImageContentChange` session replay changes.
  - `StringResourceId` string role.
  - WASM stack-trace symbolication fields.
- Regenerate the schema-derived TypeScript types.
- Add the corresponding SDK `ChangeType.ImageContent` and `StringRole.ResourceId` constants.
- Update string ID handling and change encoding/decoding for image resource IDs.
- Add a decoder regression test for image content resource references.

## Test instructions

Run:

```bash
yarn typecheck
yarn test:unit --spec packages/browser-rum/src/domain/record/encoding/changeDecoder.spec.ts
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file