### PR TITLE
🐛 Keep inlining link stylesheets after a client-side navigation

### DIFF
--- a/packages/browser-rum/src/domain/record/serialization/serializeAttributes.spec.ts
+++ b/packages/browser-rum/src/domain/record/serialization/serializeAttributes.spec.ts
@@ -21,6 +21,11 @@ import { createSerializationStats } from './serializationStats'
 
 const CSS_FILE_URL = '/base/packages/browser-rum/test/record/toto.css'
 
+// A base URL whose directory is '/client/', and a relative href that climbs one level out of
+// it to reach the stylesheet served at '/base/packages/...'.
+const RELATIVE_CSS_BASE_URL = `${location.origin}/client/new-quote`
+const RELATIVE_CSS_HREF = '../base/packages/browser-rum/test/record/relativeStylesheet.css'
+
 const PRIVACY_LEVELS = Object.keys({
   [NodePrivacyLevel.ALLOW]: true,
   [NodePrivacyLevel.HIDDEN]: true,
@@ -367,6 +372,39 @@ describe('serializeVirtualAttributes', () => {
       stats.cssText = { ...emptyStats }
     }
 
+    /**
+     * Appends a really loaded `<link rel="stylesheet">` whose `href` attribute is relative, in an
+     * isolated iframe so that changing the base URL can't affect the rest of the test run.
+     */
+    async function appendLinkWithRelativeHref(): Promise<{
+      link: HTMLLinkElement
+      sheet: CSSStyleSheet
+      setBaseUrl: (url: string) => void
+    }> {
+      const iframe = document.createElement('iframe')
+      registerCleanupTask(() => {
+        iframe.remove()
+      })
+
+      const loaded = new Promise((resolve) => iframe.addEventListener('load', resolve))
+      iframe.srcdoc = `
+        <base href="${RELATIVE_CSS_BASE_URL}">
+        <link rel="stylesheet" href="${RELATIVE_CSS_HREF}">
+      `
+      document.body.appendChild(iframe)
+      await loaded
+
+      const iframeDocument = iframe.contentDocument!
+      const link = iframeDocument.querySelector('link')!
+      expect(link.sheet).withContext('the stylesheet should have loaded').not.toBeNull()
+
+      return {
+        link,
+        sheet: link.sheet!,
+        setBaseUrl: (url: string) => iframeDocument.querySelector('base')!.setAttribute('href', url),
+      }
+    }
+
     it('handles link element stylesheets', async () => {
       const cssBlob = new Blob([cssText], { type: 'text/css' })
       const cssUrl = URL.createObjectURL(cssBlob)
@@ -394,6 +432,21 @@ describe('serializeVirtualAttributes', () => {
     it('handles style element stylesheets', () => {
       const style = appendElement(`<style>${cssText}</style>`)
       expectVirtualAttributes(style, { _cssText: cssText }, checkStats)
+    })
+
+    it('handles link element stylesheets with a relative href after the base URL changed', async () => {
+      const { link, sheet, setBaseUrl } = await appendLinkWithRelativeHref()
+
+      // Emulate a client-side navigation into a deeper directory. Only the document base
+      // URL changes; the stylesheet stays loaded and applied, as it does in the browser.
+      setBaseUrl(`${location.origin}/client/new-quote/personal-details`)
+
+      // HTMLLinkElement#href re-resolves the relative attribute against the new base URL,
+      // while CSSStyleSheet#href stays frozen at its load-time value. Matching the two is
+      // what used to lose the stylesheet (RUMS-6225).
+      expect(link.href).not.toBe(sheet.href!)
+
+      expectVirtualAttributes(link, { _cssText: cssText }, checkStats)
     })
   })
 

--- a/packages/browser-rum/src/domain/record/serialization/serializeAttributes.spec.ts
+++ b/packages/browser-rum/src/domain/record/serialization/serializeAttributes.spec.ts
@@ -21,11 +21,6 @@ import { createSerializationStats } from './serializationStats'
 
 const CSS_FILE_URL = '/base/packages/browser-rum/test/record/toto.css'
 
-// A base URL whose directory is '/client/', and a relative href that climbs one level out of
-// it to reach the stylesheet served at '/base/packages/...'.
-const RELATIVE_CSS_BASE_URL = `${location.origin}/client/new-quote`
-const RELATIVE_CSS_HREF = '../base/packages/browser-rum/test/record/relativeStylesheet.css'
-
 const PRIVACY_LEVELS = Object.keys({
   [NodePrivacyLevel.ALLOW]: true,
   [NodePrivacyLevel.HIDDEN]: true,
@@ -372,39 +367,6 @@ describe('serializeVirtualAttributes', () => {
       stats.cssText = { ...emptyStats }
     }
 
-    /**
-     * Appends a really loaded `<link rel="stylesheet">` whose `href` attribute is relative, in an
-     * isolated iframe so that changing the base URL can't affect the rest of the test run.
-     */
-    async function appendLinkWithRelativeHref(): Promise<{
-      link: HTMLLinkElement
-      sheet: CSSStyleSheet
-      setBaseUrl: (url: string) => void
-    }> {
-      const iframe = document.createElement('iframe')
-      registerCleanupTask(() => {
-        iframe.remove()
-      })
-
-      const loaded = new Promise((resolve) => iframe.addEventListener('load', resolve))
-      iframe.srcdoc = `
-        <base href="${RELATIVE_CSS_BASE_URL}">
-        <link rel="stylesheet" href="${RELATIVE_CSS_HREF}">
-      `
-      document.body.appendChild(iframe)
-      await loaded
-
-      const iframeDocument = iframe.contentDocument!
-      const link = iframeDocument.querySelector('link')!
-      expect(link.sheet).withContext('the stylesheet should have loaded').not.toBeNull()
-
-      return {
-        link,
-        sheet: link.sheet!,
-        setBaseUrl: (url: string) => iframeDocument.querySelector('base')!.setAttribute('href', url),
-      }
-    }
-
     it('handles link element stylesheets', async () => {
       const cssBlob = new Blob([cssText], { type: 'text/css' })
       const cssUrl = URL.createObjectURL(cssBlob)
@@ -435,16 +397,40 @@ describe('serializeVirtualAttributes', () => {
     })
 
     it('handles link element stylesheets with a relative href after the base URL changed', async () => {
-      const { link, sheet, setBaseUrl } = await appendLinkWithRelativeHref()
+      // A base URL whose directory is '/client/', and a relative href that climbs one level out
+      // of it to reach the stylesheet served at '/base/packages/...'.
+      const baseUrl = `${location.origin}/client/new-quote`
+      const relativeHref = '../base/packages/browser-rum/test/record/relativeStylesheet.css'
 
-      // Emulate a client-side navigation into a deeper directory. Only the document base
-      // URL changes; the stylesheet stays loaded and applied, as it does in the browser.
-      setBaseUrl(`${location.origin}/client/new-quote/personal-details`)
+      // Load the stylesheet for real, in an isolated iframe so that changing the base URL can't
+      // affect the rest of the test run.
+      const iframe = document.createElement('iframe')
+      registerCleanupTask(() => {
+        iframe.remove()
+      })
 
-      // HTMLLinkElement#href re-resolves the relative attribute against the new base URL,
-      // while CSSStyleSheet#href stays frozen at its load-time value. Matching the two is
-      // what used to lose the stylesheet (RUMS-6225).
-      expect(link.href).not.toBe(sheet.href!)
+      const loaded = new Promise((resolve) => iframe.addEventListener('load', resolve))
+      iframe.srcdoc = `
+        <base href="${baseUrl}">
+        <link rel="stylesheet" href="${relativeHref}">
+      `
+      document.body.appendChild(iframe)
+      await loaded
+
+      const iframeDocument = iframe.contentDocument!
+      const link = iframeDocument.querySelector('link')!
+      expect(link.sheet).withContext('the stylesheet should have loaded').not.toBeNull()
+
+      // Emulate a client-side navigation into a deeper directory. Only the document base URL
+      // changes; the stylesheet stays loaded and applied, as it does in the browser. `<base>` is
+      // used rather than `pushState`, which throws on a `srcdoc` document; both change
+      // `document.baseURI`, which is all `HTMLLinkElement#href` reads.
+      iframeDocument.querySelector('base')!.setAttribute('href', `${baseUrl}/personal-details`)
+
+      // HTMLLinkElement#href re-resolves the relative attribute against the new base URL, while
+      // CSSStyleSheet#href stays frozen at its load-time value. Matching the two is what used to
+      // lose the stylesheet (RUMS-6225).
+      expect(link.href).not.toBe(link.sheet!.href!)
 
       expectVirtualAttributes(link, { _cssText: cssText }, checkStats)
     })

--- a/packages/browser-rum/src/domain/record/serialization/serializeAttributes.ts
+++ b/packages/browser-rum/src/domain/record/serialization/serializeAttributes.ts
@@ -96,14 +96,12 @@ export function serializeVirtualAttributes(
   }
 
   const attrs: VirtualAttributes = {}
-  const doc = element.ownerDocument
   const tagName = normalizedTagName(element)
 
   // remote css
   if (tagName === 'link') {
-    const stylesheet = Array.from(doc.styleSheets).find((s) => s.href === (element as HTMLLinkElement).href)
-    const cssText = getCssRulesString(stylesheet)
-    if (cssText && stylesheet) {
+    const cssText = getCssRulesString((element as HTMLLinkElement).sheet)
+    if (cssText) {
       transaction.addMetric('cssText', cssText.length)
       attrs._cssText = cssText
     }

--- a/packages/browser-rum/test/record/relativeStylesheet.css
+++ b/packages/browser-rum/test/record/relativeStylesheet.css
@@ -1,0 +1,6 @@
+/* Loaded through a relative href by serializeAttributes.spec.ts, which asserts on these
+   exact rules. */
+div {
+  background-color: green;
+  top: 5px;
+}

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -33,6 +33,8 @@ const FILES = [
   // `afterEach` hooks.
   'packages/browser-core/test/forEach.spec.ts',
   'packages/browser-rum/test/record/toto.css',
+  // Served but not injected into the runner page, so its rules don't leak into other specs.
+  { pattern: 'packages/browser-rum/test/record/relativeStylesheet.css', included: false, watched: false },
 ]
 
 const FILES_SPECS = [


### PR DESCRIPTION
## Motivation

[RUMS-6225](https://datadoghq.atlassian.net/browse/RUMS-6225): a customer's Session Replay renders correctly on the SSR view, then loses all CSS on the first client-side navigation, with the player 404ing on the stylesheet URLs.

The recorder looked up a `<link>` element's stylesheet by comparing `CSSStyleSheet#href` with `HTMLLinkElement#href`. That comparison breaks after a client-side navigation: `CSSStyleSheet#href` is frozen at load time, while `HTMLLinkElement#href` re-resolves a relative attribute against `document.baseURI`, which `pushState` changes. Once the new path sits in a different directory no stylesheet matches, `_cssText` is no longer emitted, and the player falls back to fetching the raw relative `href` re-based on the new view URL, which 404s.

Reported on a SvelteKit application, whose `kit.paths.relative` defaults to `true` and therefore emits relative asset paths during SSR, but this is not framework-specific: any build emitting relative stylesheet paths, combined with a client-side navigation that changes the path directory, is affected. Verified present in the customer's `7.4.0` and still at `main`.

Since the CSS is absent from the segments that were already recorded, this only affects new recordings: existing sessions cannot be repaired retroactively.

## Changes

- `serializeVirtualAttributes()` now reads the stylesheet from `HTMLLinkElement#sheet` instead of finding it in `document.styleSheets` by `href` equality. This is the canonical accessor, symmetric with the `<style>` branch right below it, and immune to base URL changes.
- Dropped the now-dead `&& stylesheet` guard, since `getCssRulesString(null)` already returns `null`, and the `doc` local whose only use was the removed lookup. `document.styleSheets` is no longer read anywhere in the recorder.
- Added a regression test in `serializeAttributes.spec.ts`. It loads a real stylesheet through a relative `href` inside an isolated iframe, then rewrites the base URL to a deeper directory. The iframe keeps the base URL change from affecting the rest of the run, and `<base>` is used rather than `pushState` because a `srcdoc` document is `about:srcdoc`, where `pushState` throws; both change `document.baseURI`, which is all `HTMLLinkElement#href` reads.
- Added `packages/browser-rum/test/record/relativeStylesheet.css` as the served fixture, since the existing `toto.css` is empty and yields no `cssText`. Registered in `test/unit/karma.base.conf.js` with `included: false` so its rules are served without being injected into the runner page.

## Test instructions

- `yarn test:unit --spec 'packages/browser-rum/src/domain/record/serialization/serializeAttributes.spec.ts'` passes (13 specs). Restoring only `serializeAttributes.ts` from `main` makes the new spec fail, so the test genuinely pins the regression.
- The full `browser-rum` suite passes (781 specs). The three existing `<link>` specs in `serializeNode.stylesheet.spec.ts` stub `target.sheet` and use absolute hrefs, so they were blind to this and remain green.
- Verified end to end with `yarn dev-server`: a page served one directory deep, carrying a `<link rel="stylesheet">` with a relative `href` that climbs out of that directory, plus a button doing a `pushState` into a deeper path. Reading the decoded segments back from `yarn dev-server intake`, the post-navigation view carries no CSS at all before the fix, and the same CSS as the initial view after it.
- Relative `url()` inside the inlined CSS stays correct, since `getCssRulesString()` absolutizes against `CSSStyleSheet#href`, which is the load-time URL. Confirmed on the same repro: the post-navigation view still resolves them against the stylesheet's original directory rather than the shifted one.
- No e2e test: the Playwright harness serves pages from a fixed path, so reproducing "relative `href` plus a `pushState` that changes directory" would require new fixtures for coverage the unit test already pins in a real browser.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

[RUMS-6225]: https://datadoghq.atlassian.net/browse/RUMS-6225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ