### PR TITLE
👷 Rename StringResourceId to StringRoleResourceId

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "woke": "scripts/cli woke"
   },
   "devDependencies": {
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=3eb091af81e4c1a563bcd335222fed86f5bc8bc7",
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=ab3e7c5a13f1a6fed3d63bb22f1e8a9ebaa25671",
     "@eslint/js": "10.0.1",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@microsoft/api-extractor": "7.58.12",

--- a/packages/browser-rum/src/types/sessionReplay.ts
+++ b/packages/browser-rum/src/types/sessionReplay.ts
@@ -199,7 +199,7 @@ export type StringRoleId =
   | StringRoleFormInput
   | StringRoleCSS
   | StringRoleURL
-  | StringResourceId
+  | StringRoleResourceId
 /**
  * The default string role, used for uncategorized strings. Strings added by an AddStringChange are added to this string role.
  */
@@ -235,7 +235,7 @@ export type StringRoleURL = 7
 /**
  * A string role containing resource IDs.
  */
-export type StringResourceId = 8
+export type StringRoleResourceId = 8
 /**
  * Schema representing the addition of a new #document node.
  *

--- a/packages/browser-rum/src/types/sessionReplayConstants.ts
+++ b/packages/browser-rum/src/types/sessionReplayConstants.ts
@@ -99,7 +99,7 @@ export const StringRole: {
   FormInput: SessionReplay.StringRoleFormInput
   Css: SessionReplay.StringRoleCSS
   Url: SessionReplay.StringRoleURL
-  ResourceId: SessionReplay.StringResourceId
+  ResourceId: SessionReplay.StringRoleResourceId
 } = {
   Default: 0,
   NodeName: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -712,10 +712,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/rum-events-format@DataDog/rum-events-format#commit=3eb091af81e4c1a563bcd335222fed86f5bc8bc7":
+"@datadog/rum-events-format@DataDog/rum-events-format#commit=ab3e7c5a13f1a6fed3d63bb22f1e8a9ebaa25671":
   version: 0.0.0
-  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=3eb091af81e4c1a563bcd335222fed86f5bc8bc7"
-  checksum: 10c0/0e15dd8544b13b6dbb9e32b3242db3766afd343c7632bac6cad24d8a89a25af3cf1cd3dd1490477543ca92167b78426b8bdf057e16fac0c7890bf9d7f9e4375e
+  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=ab3e7c5a13f1a6fed3d63bb22f1e8a9ebaa25671"
+  checksum: 10c0/2de9683a9f25443be33b1970f7fdd888beac24e4996edbe245744d9ce2d544e12ee5a80abcc503e3758edc457a4a7e552af515097dacf2f27f54fb45db301a4c
   languageName: node
   linkType: hard
 
@@ -6098,7 +6098,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "browser-sdk@workspace:."
   dependencies:
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=3eb091af81e4c1a563bcd335222fed86f5bc8bc7"
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=ab3e7c5a13f1a6fed3d63bb22f1e8a9ebaa25671"
     "@eslint/js": "npm:10.0.1"
     "@jsdevtools/coverage-istanbul-loader": "npm:3.0.5"
     "@microsoft/api-extractor": "npm:7.58.12"


### PR DESCRIPTION
## Motivation

In [this `rum-events-format` PR](https://github.com/DataDog/rum-events-format/pull/443), we corrected an oversight in the recent session replay schema changes by renaming `StringResourceId` to `StringRoleResourceId`. We need to sync the schema definitions in this repo to propagate the change.

## Changes

This PR updates `rum-events-format`, syncs the schema definitions, and updates the only reference to the old name that existed in the current codebase.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
