### PR TITLE
✨ allow for the the synthetics.lighthouse object

### DIFF
--- a/packages/browser-rum-core/src/domain/assembly.spec.ts
+++ b/packages/browser-rum-core/src/domain/assembly.spec.ts
@@ -66,6 +66,43 @@ describe('rum assembly', () => {
           expect((serverRumEvents[0].view as any).performance.lcp.resource_url).toBe('modified_url')
         })
 
+        it('should allow adding synthetics.lighthouse on view events', () => {
+          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+            partialConfiguration: {
+              beforeSend: (event) => {
+                if (event.type === RumEventType.VIEW && event.synthetics) {
+                  event.synthetics.lighthouse = {
+                    accessibility: 67,
+                    agentic: 50,
+                    best_practices: 63,
+                    performance: 92,
+                    seo: 98,
+                  }
+                }
+              },
+            },
+          })
+
+          notifyRawRumEvent(lifeCycle, {
+            rawRumEvent: createRawRumEvent(RumEventType.VIEW, {
+              synthetics: { test_id: 'test-abc', result_id: 'result-xyz', injected: true },
+            }),
+          })
+
+          expect(serverRumEvents[0].synthetics).toEqual({
+            test_id: 'test-abc',
+            result_id: 'result-xyz',
+            injected: true,
+            lighthouse: {
+              accessibility: 67,
+              agentic: 50,
+              best_practices: 63,
+              performance: 92,
+              seo: 98,
+            },
+          })
+        })
+
         it('should allow modification of error.handling_stack', () => {
           const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {

--- a/packages/browser-rum-core/src/domain/assembly.ts
+++ b/packages/browser-rum-core/src/domain/assembly.ts
@@ -24,6 +24,7 @@ const COMMON_MODIFIABLE_FIELD_PATHS: ModifiableFieldPaths = {
 const MODIFIABLE_FIELD_PATHS_BY_EVENT: Record<AssembledRumEvent['type'], ModifiableFieldPaths> = {
   [RumEventType.VIEW]: {
     ...COMMON_MODIFIABLE_FIELD_PATHS,
+    'synthetics.lighthouse': 'object',
     'view.performance.lcp.resource_url': 'string',
   },
   [RumEventType.ERROR]: {


### PR DESCRIPTION
## Motivation

This PR allows for the `synthetics.lighthouse` object to be modified for views. This object will be used to store the results obtained from running a lighthouse audit from a synthetic test

## Changes

 Adds `synthetics.lighthouse` to the modifiable paths of a view event

## Test instructions

No testing needed

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
