### PR TITLE
✨ Attach debug IDs to debugger snapshots

### DIFF
--- a/packages/browser-debugger/src/domain/api.spec.ts
+++ b/packages/browser-debugger/src/domain/api.spec.ts
@@ -1,10 +1,11 @@
 import { globalObject } from '@datadog/js-core/util'
-import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
+import { mockClock, mockSourceCodeContext, registerCleanupTask } from '@datadog/browser-core/test'
 import { onEntry, onReturn, onThrow, initDebuggerTransport, resetDebuggerTransport } from './api'
 import { display } from './display'
 import { addProbe, removeProbe, getProbes, clearProbes } from './probes'
 import type { Probe } from './probes'
 import { createProbe } from './probe.specHelper'
+import { captureStackTrace } from './stacktrace'
 
 const DEFAULT_PROBE_FUNCTION_ID = 'test.js;testMethod'
 const thisArg = {}
@@ -515,6 +516,69 @@ describe('api', () => {
       onEntry(probes, thisArg)
       onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('debug IDs', () => {
+    function makeStack(topFrameUrl: string) {
+      return `Error: context
+    at init (${topFrameUrl}:41:27)
+    at HTMLButtonElement.onclick (http://source-code-context-spec.example.com/runtime.js:107:146)`
+    }
+
+    it('should attach atomic URL and debug ID pairs at the top level', () => {
+      const entryUrl = captureStackTrace()[0].fileName
+      mockSourceCodeContext({
+        [makeStack(entryUrl)]: { service: 'entry-service', version: '1.2.3', ddDebugId: 'entry-id' },
+      })
+
+      addProbe(createProbe())
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
+
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      expect(payload._dd).toEqual({ debug_ids: [{ url: entryUrl, id: 'entry-id' }] })
+    })
+
+    it('should attach debug IDs from throwable and entry frame URLs', () => {
+      const entryUrl = captureStackTrace()[0].fileName
+      const throwableUrl = 'http://throwable.example.com/bundle.js?cache=1'
+      mockSourceCodeContext({
+        [makeStack(entryUrl)]: { ddDebugId: 'entry-id' },
+        [makeStack(throwableUrl)]: { ddDebugId: 'throwable-id' },
+      })
+
+      const error = new Error('boom')
+      error.stack = `Error: boom
+    at throwFn (${throwableUrl}:10:2)`
+
+      addProbe(createProbe())
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
+      onEntry(probes, thisArg)
+      onThrow(probes, error, thisArg)
+
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      expect(payload._dd.debug_ids).toEqual(
+        jasmine.arrayWithExactContents([
+          { url: throwableUrl, id: 'throwable-id' },
+          { url: entryUrl, id: 'entry-id' },
+        ])
+      )
+    })
+
+    it('should omit _dd when no source code context matches', () => {
+      mockSourceCodeContext({
+        [makeStack('http://unrelated.example.com/bundle.js')]: { ddDebugId: 'unrelated-id' },
+      })
+
+      addProbe(createProbe())
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
+
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      expect(payload._dd).toBeUndefined()
     })
   })
 

--- a/packages/browser-debugger/src/domain/api.ts
+++ b/packages/browser-debugger/src/domain/api.ts
@@ -1,7 +1,7 @@
 import { globalObject } from '@datadog/js-core/util'
 import type { Batch, ContextValue } from '@datadog/browser-core'
 import { timeStampNow } from '@datadog/js-core/time'
-import { buildTag, generateUUID, mergeArrays } from '@datadog/browser-core'
+import { buildDebugIdByUrl, buildTag, generateUUID, mergeArrays } from '@datadog/browser-core'
 import type { BrowserWindow, DebuggerInitConfiguration } from '../entries/main'
 import { capture, captureFields } from './capture'
 import type { CaptureContext } from './capture'
@@ -15,6 +15,7 @@ import {
   setProbeBudgetConfiguration,
 } from './probes'
 import type { ActiveEntry } from './activeEntries'
+import type { StackFrame } from './stacktrace'
 import { captureStackTrace } from './stacktrace'
 import { evaluateProbeMessage } from './template'
 import { evaluateProbeCondition, isConditionEvaluationError } from './condition'
@@ -336,11 +337,13 @@ function queueDebuggerSnapshot(probe: InitializedProbe, result: ActiveEntry): vo
         }
       : undefined
   ) as ContextValue
+  const debugIds = buildSnapshotDebugIds(result)
 
   const payload = {
     message: result.message,
     service: debuggerConfig.service,
     ddtags: getDebuggerDDtags(version),
+    _dd: (debugIds ? { debug_ids: debugIds } : undefined) as ContextValue,
     // TODO: Fill out logger with the right information
     logger: {
       name: probe.where.typeName,
@@ -373,6 +376,23 @@ function queueDebuggerSnapshot(probe: InitializedProbe, result: ActiveEntry): vo
 
   debuggerBatch.add(payload)
   recordProbeEventSent(probe)
+}
+
+function buildSnapshotDebugIds(result: ActiveEntry) {
+  const urls: string[] = []
+  appendStackFrameUrls(urls, result.return?.throwable?.stacktrace)
+  appendStackFrameUrls(urls, result.stack)
+  return buildDebugIdByUrl(urls)
+}
+
+function appendStackFrameUrls(urls: string[], stack: StackFrame[] | undefined): void {
+  if (!stack) {
+    return
+  }
+
+  for (const { fileName } of stack) {
+    urls.push(fileName)
+  }
 }
 
 function captureArguments(

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -287,7 +287,7 @@ export function microfrontendSetup(options: SetupOptions, servers: Servers) {
     header += setupExtension(options, servers)
   }
 
-  const { logsScriptUrl, rumScriptUrl } = createCrossOriginScriptUrls(servers, options)
+  const { logsScriptUrl, rumScriptUrl, debuggerScriptUrl } = createCrossOriginScriptUrls(servers, options)
 
   if (options.logs) {
     header += html`<script type="text/javascript" src="${logsScriptUrl}" crossorigin></script>`
@@ -303,6 +303,15 @@ export function microfrontendSetup(options: SetupOptions, servers: Servers) {
       DD_RUM.setGlobalContext(${JSON.stringify(options.context)})
       ;(${options.rumInit.toString()})(${formatConfiguration(options.rum, servers)})
     </script>`
+  }
+
+  if (options.debugger) {
+    header += html`
+      <script type="text/javascript" src="${debuggerScriptUrl}"></script>
+      <script type="text/javascript">
+        DD_DEBUGGER.init(${formatConfiguration(options.debugger, servers)})
+      </script>
+    `
   }
 
   header += html`<script type="module" src="/microfrontend/shell.js"></script>`

--- a/test/e2e/scenario/debugger.scenario.ts
+++ b/test/e2e/scenario/debugger.scenario.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call, camelcase */
 import { test, expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
-import { createTest } from '../lib/framework'
+import { createTest, microfrontendSetup } from '../lib/framework'
 
 const DEBUGGER_POLL_INTERVAL = 1_000
 const PROBE_WAIT_TIMEOUT = 30_000
+const DEBUG_ID_PATTERN = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i
+const DEBUG_ID_URL_PATH_PATTERN = /^\/microfrontend\/(?:chunks\/)?[^/]+\.m?js$/
 
 function makeProbe({
   id = 'test-probe-1',
@@ -228,6 +230,98 @@ test.describe('debugger', () => {
       expect(firstFrame.function).toEqual(expect.any(String))
       expect(firstFrame.fileName).toEqual(expect.any(String))
       expect(firstFrame.lineNumber).toEqual(expect.any(Number))
+    })
+
+  createTest('send exact source code context debug IDs in a debugger snapshot')
+    .withDebugger()
+    .run(async ({ intakeRegistry, datadogHttpApiControl, flushEvents, page }) => {
+      const probe = makeProbe({
+        typeName: 'TestModule',
+        methodName: 'throwingFunction',
+      })
+      datadogHttpApiControl.debugger.setDebuggerProbes([probe])
+
+      await page.reload()
+      await injectThrowingFunction(page)
+
+      const firstUrl = 'https://debugger.example.com/first.js'
+      const secondUrl = 'https://debugger.example.com/second.js'
+      await page.evaluate(
+        ({ firstUrl, secondUrl }) => {
+          ;(window as any).DD_SOURCE_CODE_CONTEXT = {
+            [`Error: context\n    at first (${firstUrl}:1:1)`]: { ddDebugId: 'first-debug-id' },
+            [`Error: context\n    at second (${secondUrl}:1:1)`]: { ddDebugId: 'second-debug-id' },
+          }
+
+          const probes = (window as any).$dd_probes('TestModule;throwingFunction')
+          ;(window as any).$dd_entry(probes, window, { msg: 'debug IDs' })
+          const error = new Error('debug IDs')
+          error.stack = `Error: debug IDs\n    at first (${firstUrl}:10:2)\n    at second (${secondUrl}:20:3)`
+          ;(window as any).$dd_throw(probes, error, window, { msg: 'debug IDs' })
+        },
+        { firstUrl, secondUrl }
+      )
+
+      await flushEvents()
+
+      expect(intakeRegistry.debuggerEvents.length).toBeGreaterThanOrEqual(1)
+      expect((intakeRegistry.debuggerEvents[0] as any)._dd.debug_ids).toEqual([
+        { url: firstUrl, id: 'first-debug-id' },
+        { url: secondUrl, id: 'second-debug-id' },
+      ])
+    })
+
+  createTest('send well-formed build-plugin debug IDs in a debugger snapshot')
+    .withDebugger()
+    .withSetup(microfrontendSetup)
+    .run(async ({ intakeRegistry, datadogHttpApiControl, flushEvents, page, baseUrl }) => {
+      const probe = makeProbe({
+        typeName: 'TestModule',
+        methodName: 'throwingFunction',
+      })
+      datadogHttpApiControl.debugger.setDebuggerProbes([probe])
+
+      await page.reload()
+      await waitForProbe(page, 'TestModule;throwingFunction')
+      await page.locator('#app1-runtime-error').waitFor()
+
+      await page.evaluate(() => {
+        window.addEventListener(
+          'error',
+          (event) => {
+            event.preventDefault()
+            const probes = (window as any).$dd_probes('TestModule;throwingFunction')
+            if (probes && event.error) {
+              ;(window as any).$dd_entry(probes, window, {})
+              ;(window as any).$dd_throw(probes, event.error, window, {})
+            }
+          },
+          { once: true }
+        )
+      })
+
+      await page.click('#app1-runtime-error')
+      await flushEvents()
+
+      expect(intakeRegistry.debuggerEvents.length).toBeGreaterThanOrEqual(1)
+      const debugIds = (intakeRegistry.debuggerEvents[0] as any)._dd?.debug_ids as Array<{
+        url: string
+        id: string
+      }>
+      expect(debugIds).toEqual(expect.any(Array))
+      expect(debugIds.length).toBeGreaterThan(0)
+
+      for (const debugId of debugIds) {
+        expect(debugId).toEqual({
+          url: expect.any(String),
+          id: expect.any(String),
+        })
+
+        const url = new URL(debugId.url)
+        expect(url.origin).toBe(new URL(baseUrl).origin)
+        expect(url.pathname).toMatch(DEBUG_ID_URL_PATH_PATTERN)
+        expect(debugId.id).toMatch(DEBUG_ID_PATTERN)
+      }
     })
 
   createTest('fetch probes from the Delivery API after initial load')


### PR DESCRIPTION
## Motivation

Attach source-map debug IDs to Live Debugger snapshots so backend processing can associate captured snapshots with the correct source code versions.

## Changes

- Add atomic URL/debug ID pairs from snapshot entry and throwable stack frames to debugger snapshot payloads.
- Omit `_dd` when no matching source code context is available.
- Add unit and end-to-end coverage for debugger snapshot debug IDs.

## Test instructions

- Run the browser debugger unit tests and the debugger end-to-end scenario.
- Trigger a debugger snapshot from a source-mapped application and verify that the payload contains `_dd.debug_ids` with the expected URL/ID pairs.
- Verify that snapshots without matching source code context do not contain `_dd`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file