### PR TITLE
🐛 compare remote configuration payloads by deep equality, not JSON.stringify

### DIFF
--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
@@ -292,11 +292,6 @@ function extractValue(extractor: SerializedRegex, candidate: string) {
 type FetchRemoteConfigurationResult =
   { ok: true; value: RemoteConfiguration; lastModified?: number } | { ok: false; error: Error }
 
-/**
- * Reads the CDN publish time. `Last-Modified` is a CORS-safelisted response header, so it is
- * readable cross-origin without the CDN having to expose it explicitly. It carries an HTTP-date,
- * so the value is only accurate to the second.
- */
 function parseLastModified(response: Response): number | undefined {
   const header = response.headers?.get('last-modified')
   if (!header) {
@@ -364,7 +359,7 @@ function doBackgroundCacheSync(
         display.error(fetchResult.error)
       } else {
         metrics.increment('fetch', 'success')
-        cache.write(fetchResult.value, fetchResult.lastModified)
+        cache.recordSync(fetchResult.value, fetchResult.lastModified)
       }
     })
     .catch(monitorError)

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.spec.ts
@@ -161,7 +161,7 @@ describe('remoteConfigurationCache', () => {
       })
     })
 
-    describe('write', () => {
+    describe('recordSync', () => {
       let clock: Clock
 
       beforeEach(() => {
@@ -171,7 +171,7 @@ describe('remoteConfigurationCache', () => {
       it('should persist a config that can be read back', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
-        cache.write(VALID_CONFIG)
+        cache.recordSync(VALID_CONFIG)
 
         expect(cache.read()).toEqual({
           status: 'hit',
@@ -184,7 +184,7 @@ describe('remoteConfigurationCache', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
         clock.tick(5000)
-        cache.write(VALID_CONFIG, 1500)
+        cache.recordSync(VALID_CONFIG, 1500)
 
         const stored = JSON.parse(localStorage.getItem(CACHE_KEY)!)
         expect(stored).toEqual({
@@ -201,8 +201,8 @@ describe('remoteConfigurationCache', () => {
       it('should overwrite a previously stored entry', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
-        cache.write({ rum: { applicationId: 'first' } })
-        cache.write({ rum: { applicationId: 'second' } })
+        cache.recordSync({ rum: { applicationId: 'first' } })
+        cache.recordSync({ rum: { applicationId: 'second' } })
 
         expect(readHit(cache).config).toEqual({ rum: { applicationId: 'second' } })
       })
@@ -210,11 +210,11 @@ describe('remoteConfigurationCache', () => {
       it('should regenerate sync metadata when the config changed', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
-        cache.write({ rum: { applicationId: 'first' } }, 1500)
+        cache.recordSync({ rum: { applicationId: 'first' } }, 1500)
         const first = readHit(cache).metadata
 
         clock.tick(5000)
-        cache.write({ rum: { applicationId: 'second' } }, 2500)
+        cache.recordSync({ rum: { applicationId: 'second' } }, 2500)
 
         const second = readHit(cache).metadata
         expect(second.syncId).not.toBe(first.syncId)
@@ -225,11 +225,23 @@ describe('remoteConfigurationCache', () => {
       it('should not rewrite sync metadata when the config is unchanged', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
-        cache.write(VALID_CONFIG, 1500)
+        cache.recordSync(VALID_CONFIG, 1500)
         const first = readHit(cache).metadata
 
         clock.tick(5000)
-        cache.write(VALID_CONFIG, 2500)
+        cache.recordSync(VALID_CONFIG, 2500)
+
+        expect(readHit(cache).metadata).toEqual(first)
+      })
+
+      it('should not rewrite sync metadata when the config is the same but keys are reordered', () => {
+        const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
+
+        cache.recordSync({ rum: { applicationId: 'app-id', sessionSampleRate: 50 } }, 1500)
+        const first = readHit(cache).metadata
+
+        clock.tick(5000)
+        cache.recordSync({ rum: { sessionSampleRate: 50, applicationId: 'app-id' } }, 2500)
 
         expect(readHit(cache).metadata).toEqual(first)
       })
@@ -239,7 +251,7 @@ describe('remoteConfigurationCache', () => {
 
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
-        expect(() => cache.write(VALID_CONFIG)).not.toThrow()
+        expect(() => cache.recordSync(VALID_CONFIG)).not.toThrow()
       })
     })
 
@@ -252,7 +264,7 @@ describe('remoteConfigurationCache', () => {
 
       it('should stamp firstApplied and persist it when unset', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
-        cache.write(VALID_CONFIG)
+        cache.recordSync(VALID_CONFIG)
 
         clock.tick(5000)
         const metadata = cache.stampFirstApplied(readHit(cache))
@@ -264,7 +276,7 @@ describe('remoteConfigurationCache', () => {
 
       it('should reuse the firstApplied already stamped', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
-        cache.write(VALID_CONFIG)
+        cache.recordSync(VALID_CONFIG)
         const first = cache.stampFirstApplied(readHit(cache))
 
         clock.tick(60000)
@@ -275,28 +287,28 @@ describe('remoteConfigurationCache', () => {
 
       it('should preserve firstApplied when an unchanged config is refetched', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
-        cache.write(VALID_CONFIG)
+        cache.recordSync(VALID_CONFIG)
         const stamped = cache.stampFirstApplied(readHit(cache))
 
         clock.tick(5000)
-        cache.write(VALID_CONFIG)
+        cache.recordSync(VALID_CONFIG)
 
         expect(readHit(cache).metadata.firstApplied).toEqual(stamped.firstApplied)
       })
 
       it('should leave firstApplied unset when the config changed', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
-        cache.write({ rum: { applicationId: 'first' } })
+        cache.recordSync({ rum: { applicationId: 'first' } })
         cache.stampFirstApplied(readHit(cache))
 
-        cache.write({ rum: { applicationId: 'second' } })
+        cache.recordSync({ rum: { applicationId: 'second' } })
 
         expect(readHit(cache).metadata.firstApplied).toBeUndefined()
       })
 
       it('should keep the rest of the metadata intact when stamping', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
-        cache.write(VALID_CONFIG, 1500)
+        cache.recordSync(VALID_CONFIG, 1500)
         const before = readHit(cache).metadata
 
         const after = cache.stampFirstApplied(readHit(cache))

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.ts
@@ -2,6 +2,7 @@ import { timeStampNow } from '@datadog/js-core/time'
 import { generateUUID, tryJsonParse } from '@datadog/browser-core'
 import { isIndexableObject } from '@datadog/js-core/util'
 import type { TimeStamp } from '@datadog/js-core/time'
+import { isEqual } from '../view/viewDiff'
 import type { RemoteConfiguration } from './remoteConfiguration'
 
 export const CACHE_VERSION = 3
@@ -68,7 +69,7 @@ function isValidCacheEntry(value: unknown): value is CachedRemoteConfiguration {
   return hasVersion && hasConfig && hasMetadata
 }
 
-function persist(key: string, entry: CachedRemoteConfiguration) {
+function write(key: string, entry: CachedRemoteConfiguration) {
   try {
     localStorage.setItem(key, JSON.stringify(entry))
   } catch {
@@ -115,20 +116,19 @@ export function createConfigurationCache({ remoteConfigurationId }: { remoteConf
         // Ignore
       }
     },
-    write(config: RemoteConfiguration, lastModified?: number) {
+    recordSync(config: RemoteConfiguration, lastModified?: number) {
       const cached = this.read()
 
       // Only a payload change counts as a sync. The SDK sends no `If-None-Match`, so it never
       // observes a 304 and cannot otherwise tell a genuine sync from a repeated fetch of the same
       // version. Skipping the write here is also what keeps `firstApplied` alive across refetches.
       // TODO: compare on `ETag` instead once the CDN exposes it through
-      // `Access-Control-Expose-Headers`. The stringify compare is key-order sensitive, which holds
-      // only because both sides come from `JSON.parse` of the same CDN payload.
-      if (cached.status === 'hit' && JSON.stringify(cached.config) === JSON.stringify(config)) {
+      // `Access-Control-Expose-Headers`.
+      if (cached.status === 'hit' && isEqual(cached.config, config)) {
         return
       }
 
-      persist(key, {
+      write(key, {
         version: CACHE_VERSION,
         config,
         metadata: { lastModified, lastSynced: timeStampNow(), syncId: generateUUID() },
@@ -145,7 +145,7 @@ export function createConfigurationCache({ remoteConfigurationId }: { remoteConf
       }
 
       const metadata: RemoteConfigurationMetadata = { ...cached.metadata, firstApplied: timeStampNow() }
-      persist(key, { version: CACHE_VERSION, config: cached.config, metadata })
+      write(key, { version: CACHE_VERSION, config: cached.config, metadata })
 
       return metadata
     },


### PR DESCRIPTION
## Motivation

Two small follow-ups to #5001 worth landing on their own: the sync-detection comparison was doing a raw `JSON.stringify` equality check, sensitive to key order, and two cache methods ended up both named `write` despite doing different things.

## Changes

- `recordSync`'s change detection now uses `isEqual` (from `viewDiff`, already used elsewhere in the RUM domain for deep comparison) instead of `JSON.stringify(a) === JSON.stringify(b)`, so it no longer depends on the CDN serializing keys in a stable order.
- Renamed the private `persist` helper to `write` (it's the generic, reusable localStorage write, shared by `recordSync` and `stampFirstApplied`), and renamed the public `write` method to `recordSync` (the specific "record that a sync happened" operation). Names now describe what each one actually does.

No behavior change beyond the comparison fix.

## Test instructions

Added a test that constructs the same config with keys in a different order and asserts `recordSync` still treats it as unchanged, this fails against the old `JSON.stringify` comparison and passes with `isEqual`. Existing tests cover the renamed call sites.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file