### PR TITLE
⚗️ Replace canvas recording knobs with quality presets, dedupe downscaling for hashing, and switch to WebP

### DIFF
--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '@datadog/browser-core/test'
 import type { RumInitConfiguration } from './configuration'
 import {
+  CanvasRecordingQuality,
   DEFAULT_PROPAGATOR_TYPES,
   DEFAULT_TRACKED_RESOURCE_HEADERS,
   serializeRumConfiguration,
@@ -392,7 +393,7 @@ describe('validateAndBuildRumConfiguration', () => {
         addExperimentalFeatures([ExperimentalFeature.SESSION_REPLAY_RECORD_CANVAS])
       })
 
-      it('uses one frame per second by default when enabled', () => {
+      it('uses the medium quality preset by default when enabled', () => {
         const configuration = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
           sessionReplayCanvasRecording: { enable: true },
@@ -400,64 +401,48 @@ describe('validateAndBuildRumConfiguration', () => {
 
         expect(configuration.sessionReplayCanvasRecording).toEqual({
           enable: true,
-          maxFramesPerSecond: 1,
+          maxFramesPerSecond: 4,
           hashingMaxDimension: 100,
           maxImageDimension: 1000,
+          encodeQuality: 0.5,
         })
       })
 
-      it('uses the configured frame rate', () => {
+      it('uses the configured quality preset', () => {
         const configuration = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
           sessionReplayCanvasRecording: {
             enable: true,
-            maxFramesPerSecond: 2.5,
-            hashingMaxDimension: 50,
-            maxImageDimension: 500,
+            quality: CanvasRecordingQuality.LOW,
           },
         })!
 
         expect(configuration.sessionReplayCanvasRecording).toEqual({
           enable: true,
-          maxFramesPerSecond: 2.5,
+          maxFramesPerSecond: 1,
           hashingMaxDimension: 50,
-          maxImageDimension: 500,
+          maxImageDimension: 600,
+          encodeQuality: 0.3,
         })
       })
 
-      it('preserves the configured options when disabled', () => {
+      it('resolves to undefined when disabled regardless of the configured quality', () => {
         const configuration = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
           sessionReplayCanvasRecording: {
             enable: false,
-            maxFramesPerSecond: 2.5,
-            hashingMaxDimension: 50,
-            maxImageDimension: 500,
+            quality: CanvasRecordingQuality.HIGH,
           },
         })!
 
-        expect(configuration.sessionReplayCanvasRecording).toEqual({
-          enable: false,
-          maxFramesPerSecond: 2.5,
-          hashingMaxDimension: 50,
-          maxImageDimension: 500,
-        })
+        expect(configuration.sessionReplayCanvasRecording).toBeUndefined()
       })
 
-      it('rejects a hashing dimension above 100 pixels', () => {
+      it('rejects an invalid quality preset', () => {
         expect(
           validateAndBuildRumConfiguration({
             ...DEFAULT_INIT_CONFIGURATION,
-            sessionReplayCanvasRecording: { enable: true, hashingMaxDimension: 101 },
-          })
-        ).toBeUndefined()
-      })
-
-      it('rejects an image dimension above 1000 pixels', () => {
-        expect(
-          validateAndBuildRumConfiguration({
-            ...DEFAULT_INIT_CONFIGURATION,
-            sessionReplayCanvasRecording: { enable: true, maxImageDimension: 1001 },
+            sessionReplayCanvasRecording: { enable: true, quality: 'ultra' as any },
           })
         ).toBeUndefined()
       })
@@ -1181,7 +1166,7 @@ describe('serializeRumConfiguration', () => {
       trackResourceHeaders: true,
       betaEnableViewUpdates: true,
       betaTrackWebSockets: false,
-      sessionReplayCanvasRecording: { enable: true, maxFramesPerSecond: 2.5 },
+      sessionReplayCanvasRecording: { enable: true, quality: CanvasRecordingQuality.HIGH },
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -390,6 +390,18 @@ export interface RumInitConfiguration extends InitConfiguration {
 
 /**
  * Recording quality presets for canvas capture. See {@link RumInitConfiguration.sessionReplayCanvasRecording}.
+ *
+ * @example
+ * ```ts
+ * datadogRum.init({
+ *   // ...
+ *   sessionReplayCanvasRecording: {
+ *     enable: true,
+ *     quality: CanvasRecordingQuality.MEDIUM,
+ *   },
+ * })
+ * ```
+ * @hidden
  */
 export const CanvasRecordingQuality = {
   LOW: 'low',

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -243,27 +243,11 @@ export interface RumInitConfiguration extends InitConfiguration {
         enable: boolean
 
         /**
-         * The maximum number of canvas frames recorded per second, between 0 and 5. Setting this option to `0` disables canvas frame recording.
+         * Trades frame rate and image resolution for bandwidth. See {@link CanvasRecordingQuality}.
          *
-         * @defaultValue 1
+         * @defaultValue 'medium'
          */
-        maxFramesPerSecond?: number | undefined
-
-        /**
-         * The maximum width or height, in pixels, of the image used for canvas change detection, between 1 and 100.
-         * Images are downscaled proportionally to fit within this bound and smaller images are not upscaled.
-         *
-         * @defaultValue 100
-         */
-        hashingMaxDimension?: number | undefined
-
-        /**
-         * The maximum width or height, in pixels, of recorded canvas images, between 1 and 1000. Images are downscaled proportionally
-         * to fit within this bound and smaller images are not upscaled.
-         *
-         * @defaultValue 1000
-         */
-        maxImageDimension?: number | undefined
+        quality?: CanvasRecordingQuality | undefined
       }
     | undefined
 
@@ -404,6 +388,48 @@ export interface RumInitConfiguration extends InitConfiguration {
   betaTrackWebSockets?: boolean | undefined
 }
 
+/**
+ * Recording quality presets for canvas capture. See {@link RumInitConfiguration.sessionReplayCanvasRecording}.
+ */
+export const CanvasRecordingQuality = {
+  LOW: 'low',
+  MEDIUM: 'medium',
+  HIGH: 'high',
+} as const
+export type CanvasRecordingQuality = (typeof CanvasRecordingQuality)[keyof typeof CanvasRecordingQuality]
+
+/**
+ * The resolved canvas recording tuning behind each {@link CanvasRecordingQuality} preset.
+ */
+export interface CanvasRecordingConfiguration {
+  enable: true
+  maxFramesPerSecond: number
+  hashingMaxDimension: number
+  maxImageDimension: number
+  encodeQuality: number
+}
+
+const CANVAS_RECORDING_QUALITY_PRESETS: Record<CanvasRecordingQuality, Omit<CanvasRecordingConfiguration, 'enable'>> = {
+  [CanvasRecordingQuality.LOW]: {
+    maxFramesPerSecond: 1,
+    hashingMaxDimension: 50,
+    maxImageDimension: 600,
+    encodeQuality: 0.3,
+  },
+  [CanvasRecordingQuality.MEDIUM]: {
+    maxFramesPerSecond: 4,
+    hashingMaxDimension: 100,
+    maxImageDimension: 1000,
+    encodeQuality: 0.5,
+  },
+  [CanvasRecordingQuality.HIGH]: {
+    maxFramesPerSecond: 8,
+    hashingMaxDimension: 100,
+    maxImageDimension: 1280,
+    encodeQuality: 0.75,
+  },
+}
+
 export type FeatureFlagsForEvents = 'vital' | 'action' | 'long_task' | 'resource'
 
 /**
@@ -459,9 +485,7 @@ export const RUM_SCHEMA = {
     type: 'schema',
     schema: {
       enable: { type: 'boolean', required: true },
-      maxFramesPerSecond: { type: 'number', min: 0, max: 5, default: 1 },
-      hashingMaxDimension: { type: 'number', min: 1, max: 100, default: 100 },
-      maxImageDimension: { type: 'number', min: 1, max: 1000, default: 1000 },
+      quality: { type: 'enum', values: CanvasRecordingQuality, default: CanvasRecordingQuality.MEDIUM },
     },
   },
 
@@ -528,13 +552,17 @@ export const RUM_SCHEMA = {
   },
 } as const
 
-export type RumConfiguration = Omit<InferredConfig<typeof RUM_SCHEMA>, 'allowedTracingUrls'> & {
+export type RumConfiguration = Omit<
+  InferredConfig<typeof RUM_SCHEMA>,
+  'allowedTracingUrls' | 'sessionReplayCanvasRecording'
+> & {
   allowedTracingUrls: TracingOption[]
   betaEnableViewUpdates: boolean
   rulePsr: number | undefined
   trackResourceHeaders: MatchHeader[]
   allowedGraphQlUrls: GraphQlUrlOption[]
   remoteConfigurationId: string | undefined
+  sessionReplayCanvasRecording: CanvasRecordingConfiguration | undefined
 }
 
 /**
@@ -585,9 +613,11 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
-  const sessionReplayCanvasRecording = isExperimentalFeatureEnabled(ExperimentalFeature.SESSION_REPLAY_RECORD_CANVAS)
-    ? config.sessionReplayCanvasRecording
-    : undefined
+  const sessionReplayCanvasRecording =
+    isExperimentalFeatureEnabled(ExperimentalFeature.SESSION_REPLAY_RECORD_CANVAS) &&
+    config.sessionReplayCanvasRecording?.enable
+      ? { enable: true as const, ...CANVAS_RECORDING_QUALITY_PRESETS[config.sessionReplayCanvasRecording.quality] }
+      : undefined
 
   return {
     ...config,

--- a/packages/browser-rum-core/src/index.ts
+++ b/packages/browser-rum-core/src/index.ts
@@ -51,7 +51,7 @@ export type {
   RemoteConfiguration,
   MatchHeader,
 } from './domain/configuration'
-export { DEFAULT_TRACKED_RESOURCE_HEADERS } from './domain/configuration'
+export { DEFAULT_TRACKED_RESOURCE_HEADERS, CanvasRecordingQuality } from './domain/configuration'
 export { DEFAULT_PROGRAMMATIC_ACTION_NAME_ATTRIBUTE } from './domain/action/actionNameConstants'
 export { STABLE_ATTRIBUTES } from './domain/getSelectorFromElement'
 export * from './browser/htmlDomUtils'

--- a/packages/browser-rum-slim/src/entries/main.ts
+++ b/packages/browser-rum-slim/src/entries/main.ts
@@ -67,7 +67,7 @@ export type {
   RumWebSocketResourceEventDomainContext,
   RumLongTaskEventDomainContext,
 } from '@datadog/browser-rum-core'
-export { DEFAULT_TRACKED_RESOURCE_HEADERS } from '@datadog/browser-rum-core'
+export { DEFAULT_TRACKED_RESOURCE_HEADERS, CanvasRecordingQuality } from '@datadog/browser-rum-core'
 export { DefaultPrivacyLevel } from '@datadog/browser-core'
 
 /**

--- a/packages/browser-rum/src/domain/record/canvas/canvasHash.ts
+++ b/packages/browser-rum/src/domain/record/canvas/canvasHash.ts
@@ -1,25 +1,25 @@
 import { mockable } from '@datadog/browser-core'
 import { globalObject } from '@datadog/js-core/util'
 import type { CanvasSnapshot } from './canvasSnapshot'
+import { createDownscaledCanvas } from './canvasSnapshot'
 
 export function computeImageHash(snapshot: CanvasSnapshot, maxHashDimension: number): Promise<string | undefined> {
   const { height: sourceHeight, width: sourceWidth } = snapshot.source
-  const scale = Math.min(1, maxHashDimension / Math.max(sourceWidth, sourceHeight))
-  const width = Math.max(1, Math.round(sourceWidth * scale))
-  const height = Math.max(1, Math.round(sourceHeight * scale))
-
-  const thumbnail = document.createElement('canvas')
-  thumbnail.width = width
-  thumbnail.height = height
+  // The snapshot is already frozen, so if it already fits, hash it directly instead of downscaling it again.
+  const thumbnail =
+    Math.max(sourceWidth, sourceHeight) <= maxHashDimension
+      ? snapshot.source
+      : createDownscaledCanvas(snapshot.source, sourceWidth, sourceHeight, maxHashDimension)
+  if (!thumbnail) {
+    return Promise.resolve(undefined)
+  }
 
   const context = thumbnail.getContext('2d')
   if (!context) {
     return Promise.resolve(undefined)
   }
-  context.imageSmoothingQuality = 'low'
-  context.drawImage(snapshot.source, 0, 0, width, height)
 
-  const data = context.getImageData(0, 0, width, height).data
+  const data = context.getImageData(0, 0, thumbnail.width, thumbnail.height).data
   // crypto.subtle is only exposed in secure contexts, so it is missing on plain HTTP pages.
   const subtleCrypto = mockable(globalObject.crypto?.subtle)
   if (!subtleCrypto) {

--- a/packages/browser-rum/src/domain/record/canvas/canvasImage.specHelper.ts
+++ b/packages/browser-rum/src/domain/record/canvas/canvasImage.specHelper.ts
@@ -1,0 +1,13 @@
+// Some browsers (e.g. older Firefox/Safari versions) don't support encoding canvases as WebP and
+// silently fall back to PNG, as mandated by the spec for unsupported `toBlob`/`toDataURL` types.
+export function supportsWebPEncoding(): boolean {
+  return document.createElement('canvas').toDataURL('image/webp').startsWith('data:image/webp')
+}
+
+// Lossy WebP encoding can shift channel values by a few units, so compare with a tolerance instead
+// of an exact match.
+export function expectPixelApprox(actual: number[], expected: number[]) {
+  actual.forEach((value, index) => {
+    expect(Math.abs(value - expected[index])).toBeLessThan(10)
+  })
+}

--- a/packages/browser-rum/src/domain/record/canvas/canvasSnapshot.spec.ts
+++ b/packages/browser-rum/src/domain/record/canvas/canvasSnapshot.spec.ts
@@ -1,6 +1,7 @@
 import { registerCleanupTask } from '@datadog/browser-core/test'
 import type { CanvasSnapshot } from './canvasSnapshot'
 import { captureCanvasImage, createCanvasSnapshot } from './canvasSnapshot'
+import { expectPixelApprox, supportsWebPEncoding } from './canvasImage.specHelper'
 
 describe('createCanvasSnapshot', () => {
   it('downscales the snapshot to the configured maximum dimension', () => {
@@ -34,17 +35,17 @@ describe('createCanvasSnapshot', () => {
 
     fill(canvas, 'blue')
 
-    expect(await imagePixels((await captureCanvasImage(snapshot, 1))!)).toEqual([255, 0, 0, 255])
+    expectPixelApprox(await imagePixels((await captureCanvasImage(snapshot, 1))!), [255, 0, 0, 255])
   })
 })
 
 describe('captureCanvasImage', () => {
-  it('encodes the snapshot as a WebP image', async () => {
+  it('encodes the snapshot as WebP, or PNG when the browser does not support WebP encoding', async () => {
     const snapshot = createSnapshot(createCanvas(2, 2), 1000)
 
     const image = await captureCanvasImage(snapshot, 0.5)
 
-    expect(image?.type).toBe('image/webp')
+    expect(image?.type).toBe(supportsWebPEncoding() ? 'image/webp' : 'image/png')
   })
 
   it('encodes an image with the dimensions of the snapshot', async () => {
@@ -61,7 +62,7 @@ describe('captureCanvasImage', () => {
 
     const image = await captureCanvasImage(snapshot, 1)
 
-    expect(await imagePixels(image!)).toEqual([255, 0, 0, 255, 0, 0, 255, 255])
+    expectPixelApprox(await imagePixels(image!), [255, 0, 0, 255, 0, 0, 255, 255])
   })
 })
 

--- a/packages/browser-rum/src/domain/record/canvas/canvasSnapshot.spec.ts
+++ b/packages/browser-rum/src/domain/record/canvas/canvasSnapshot.spec.ts
@@ -34,23 +34,23 @@ describe('createCanvasSnapshot', () => {
 
     fill(canvas, 'blue')
 
-    expect(await imagePixels((await captureCanvasImage(snapshot))!)).toEqual([255, 0, 0, 255])
+    expect(await imagePixels((await captureCanvasImage(snapshot, 1))!)).toEqual([255, 0, 0, 255])
   })
 })
 
 describe('captureCanvasImage', () => {
-  it('encodes the snapshot as a PNG image', async () => {
+  it('encodes the snapshot as a WebP image', async () => {
     const snapshot = createSnapshot(createCanvas(2, 2), 1000)
 
-    const image = await captureCanvasImage(snapshot)
+    const image = await captureCanvasImage(snapshot, 0.5)
 
-    expect(image?.type).toBe('image/png')
+    expect(image?.type).toBe('image/webp')
   })
 
   it('encodes an image with the dimensions of the snapshot', async () => {
     const snapshot = createSnapshot(createCanvas(4, 2), 2)
 
-    const image = await captureCanvasImage(snapshot)
+    const image = await captureCanvasImage(snapshot, 1)
 
     expect(await imageSize(image!)).toEqual([2, 1])
   })
@@ -59,7 +59,7 @@ describe('captureCanvasImage', () => {
     // Left half red, right half blue: a cropped image would be fully red.
     const snapshot = createSnapshot(createCanvas(4, 2, ['red', 'blue']), 2)
 
-    const image = await captureCanvasImage(snapshot)
+    const image = await captureCanvasImage(snapshot, 1)
 
     expect(await imagePixels(image!)).toEqual([255, 0, 0, 255, 0, 0, 255, 255])
   })

--- a/packages/browser-rum/src/domain/record/canvas/canvasSnapshot.ts
+++ b/packages/browser-rum/src/domain/record/canvas/canvasSnapshot.ts
@@ -7,24 +7,38 @@ export interface CanvasSnapshot {
 export function createCanvasSnapshot(canvas: HTMLCanvasElement, maxImageDimension: number): CanvasSnapshot | undefined {
   const canvasWidth = canvas.width
   const canvasHeight = canvas.height
-  const scale = Math.min(1, maxImageDimension / Math.max(canvasWidth, canvasHeight))
+  const source = createDownscaledCanvas(canvas, canvasWidth, canvasHeight, maxImageDimension)
+  if (!source) {
+    return undefined
+  }
 
-  const width = Math.max(1, Math.round(canvasWidth * scale))
-  const height = Math.max(1, Math.round(canvasHeight * scale))
+  return { canvasHeight, canvasWidth, source }
+}
 
-  const source = document.createElement('canvas')
-  source.width = width
-  source.height = height
+// Downscales `image` (of size `width`x`height`) to fit within `maxDimension` on a fresh canvas.
+export function createDownscaledCanvas(
+  image: CanvasImageSource,
+  width: number,
+  height: number,
+  maxDimension: number
+): HTMLCanvasElement | undefined {
+  const scale = Math.min(1, maxDimension / Math.max(width, height))
+  const scaledWidth = Math.max(1, Math.round(width * scale))
+  const scaledHeight = Math.max(1, Math.round(height * scale))
 
-  const context = source.getContext('2d')
+  const canvas = document.createElement('canvas')
+  canvas.width = scaledWidth
+  canvas.height = scaledHeight
+
+  const context = canvas.getContext('2d')
   if (!context) {
     return undefined
   }
 
   context.imageSmoothingQuality = 'low'
-  context.drawImage(canvas, 0, 0, width, height)
+  context.drawImage(image, 0, 0, scaledWidth, scaledHeight)
 
-  return { canvasHeight, canvasWidth, source }
+  return canvas
 }
 
 export function captureCanvasImage(snapshot: CanvasSnapshot): Promise<Blob | undefined> {

--- a/packages/browser-rum/src/domain/record/canvas/canvasSnapshot.ts
+++ b/packages/browser-rum/src/domain/record/canvas/canvasSnapshot.ts
@@ -41,10 +41,10 @@ export function createDownscaledCanvas(
   return canvas
 }
 
-export function captureCanvasImage(snapshot: CanvasSnapshot): Promise<Blob | undefined> {
+export function captureCanvasImage(snapshot: CanvasSnapshot, encodeQuality: number): Promise<Blob | undefined> {
   return new Promise((resolve) => {
     try {
-      snapshot.source.toBlob((blob) => resolve(blob ?? undefined), 'image/png')
+      snapshot.source.toBlob((blob) => resolve(blob ?? undefined), 'image/webp', encodeQuality)
     } catch {
       resolve(undefined)
     }

--- a/packages/browser-rum/src/domain/record/record.spec.ts
+++ b/packages/browser-rum/src/domain/record/record.spec.ts
@@ -82,6 +82,7 @@ describe('record', () => {
           maxFramesPerSecond: 1,
           hashingMaxDimension: 100,
           maxImageDimension: 1000,
+          encodeQuality: 0.5,
         },
       })
 
@@ -109,6 +110,7 @@ describe('record', () => {
           maxFramesPerSecond: 0,
           hashingMaxDimension: 100,
           maxImageDimension: 1000,
+          encodeQuality: 0.5,
         },
       })
 

--- a/packages/browser-rum/src/domain/record/trackers/trackCanvasCapture.spec.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackCanvasCapture.spec.ts
@@ -37,7 +37,7 @@ describe('trackCanvasCapture', () => {
     canvasManager = createCanvasManager()
     document.body.appendChild(canvas)
     toBlobSpy = spyOn(HTMLCanvasElement.prototype, 'toBlob').and.callFake((callback) => {
-      callback(new Blob([], { type: 'image/png' }))
+      callback(new Blob([], { type: 'image/webp' }))
     })
 
     registerCleanupTask(() => {
@@ -59,6 +59,7 @@ describe('trackCanvasCapture', () => {
           maxFramesPerSecond: 1,
           hashingMaxDimension,
           maxImageDimension,
+          encodeQuality: 0.5,
         },
       },
     })
@@ -90,7 +91,15 @@ describe('trackCanvasCapture', () => {
     return scope.nodeIds.getOrInsert(canvas)
   }
 
-  function firstPixelOf(image: Blob) {
+  // Lossy WebP encoding can shift channel values by a few units, so compare with a tolerance
+  // instead of an exact match.
+  function expectPixelApprox(actual: number[], expected: number[]) {
+    actual.forEach((value, index) => {
+      expect(Math.abs(value - expected[index])).toBeLessThan(10)
+    })
+  }
+
+  function firstPixelOf(image: Blob): Promise<number[]> {
     return new Promise((resolve, reject) => {
       const url = URL.createObjectURL(image)
       const element = new Image()
@@ -172,7 +181,7 @@ describe('trackCanvasCapture', () => {
       return Promise.resolve(result)
     })
     replaceMockable(globalObject.crypto?.subtle, { digest: digestSpy } as unknown as SubtleCrypto)
-    // The emitted image is the assertion here, so it has to be a real PNG rather than the empty
+    // The emitted image is the assertion here, so it has to be a real WebP rather than the empty
     // blob the suite stubs in.
     toBlobSpy.and.callThrough()
 
@@ -188,14 +197,14 @@ describe('trackCanvasCapture', () => {
     await collectAsyncCalls(onCanvasCapture, 1)
     await waitForCanvasCapture()
 
-    expect(await firstPixelOf(onCanvasCapture.calls.argsFor(0)[0].image)).toEqual([255, 0, 0, 255])
+    expectPixelApprox(await firstPixelOf(onCanvasCapture.calls.argsFor(0)[0].image), [255, 0, 0, 255])
     expect(canvasManager.takeCapturableCanvases()).toEqual([canvas])
     canvasManager.markCanvas(canvas, CanvasStatus.Dirty)
 
     clock.tick(1000)
     await collectAsyncCalls(onCanvasCapture, 2)
 
-    expect(await firstPixelOf(onCanvasCapture.calls.argsFor(1)[0].image)).toEqual([0, 0, 255, 255])
+    expectPixelApprox(await firstPixelOf(onCanvasCapture.calls.argsFor(1)[0].image), [0, 0, 255, 255])
     expect(onCanvasCapture.calls.argsFor(1)[0].changeHash).not.toBe(onCanvasCapture.calls.argsFor(0)[0].changeHash)
   })
 
@@ -285,10 +294,10 @@ describe('trackCanvasCapture', () => {
         isFirstBlob = false
         resolveFirstBlob = callback
       } else {
-        callback(new Blob([], { type: 'image/png' }))
+        callback(new Blob([], { type: 'image/webp' }))
       }
     })
-    return () => resolveFirstBlob(new Blob([], { type: 'image/png' }))
+    return () => resolveFirstBlob(new Blob([], { type: 'image/webp' }))
   }
 
   const nodeIdChangeCaptureStages: Array<{ description: string; deferCapture: () => () => void }> = [

--- a/packages/browser-rum/src/domain/record/trackers/trackCanvasCapture.spec.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackCanvasCapture.spec.ts
@@ -10,6 +10,7 @@ import type { Clock } from '@datadog/browser-core/test'
 import { NodePrivacyLevel, PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK } from '@datadog/browser-rum-core'
 import type { CanvasManager } from '../canvas/canvasManager'
 import { CanvasStatus, createCanvasManager } from '../canvas/canvasManager'
+import { expectPixelApprox } from '../canvas/canvasImage.specHelper'
 import type { NodeId } from '../encoding'
 import { createRecordingScopeForTesting } from '../test/recordingScope.specHelper'
 import type { Tracker } from './tracker.types'
@@ -89,14 +90,6 @@ describe('trackCanvasCapture', () => {
     scope.nodeIds.delete(canvas)
     document.body.appendChild(canvas)
     return scope.nodeIds.getOrInsert(canvas)
-  }
-
-  // Lossy WebP encoding can shift channel values by a few units, so compare with a tolerance
-  // instead of an exact match.
-  function expectPixelApprox(actual: number[], expected: number[]) {
-    actual.forEach((value, index) => {
-      expect(Math.abs(value - expected[index])).toBeLessThan(10)
-    })
   }
 
   function firstPixelOf(image: Blob): Promise<number[]> {

--- a/packages/browser-rum/src/domain/record/trackers/trackCanvasCapture.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackCanvasCapture.ts
@@ -110,7 +110,7 @@ export const trackCanvasCapture = (scope: RecordingScope, onCanvasCapture: Canva
         return // unchanged: no capture/output
       }
 
-      const image = await captureCanvasImage(snapshot)
+      const image = await captureCanvasImage(snapshot, configuration?.encodeQuality ?? 0.5)
       if (cancelled()) {
         return
       }

--- a/packages/browser-rum/src/domain/record/trackers/trackCanvasContent.spec.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackCanvasContent.spec.ts
@@ -22,7 +22,7 @@ describe('trackCanvasContent', () => {
   })
 
   function startTracking(
-    enable = true,
+    enable: boolean = true,
     maxFramesPerSecond = 1,
     hashingMaxDimension = 100,
     maxImageDimension = 1000
@@ -30,7 +30,9 @@ describe('trackCanvasContent', () => {
     const scope = createRecordingScopeForTesting({
       canvasManager,
       configuration: {
-        sessionReplayCanvasRecording: { enable, maxFramesPerSecond, hashingMaxDimension, maxImageDimension },
+        sessionReplayCanvasRecording: enable
+          ? { enable: true, maxFramesPerSecond, hashingMaxDimension, maxImageDimension, encodeQuality: 0.5 }
+          : undefined,
       },
     })
     scope.nodeIds.getOrInsert(canvas)
@@ -87,6 +89,7 @@ describe('trackCanvasContent', () => {
           maxFramesPerSecond: 1,
           hashingMaxDimension: 100,
           maxImageDimension: 1000,
+          encodeQuality: 0.5,
         },
       },
     })

--- a/packages/browser-rum/src/entries/main.ts
+++ b/packages/browser-rum/src/entries/main.ts
@@ -79,7 +79,7 @@ export type {
   RumLongTaskEventDomainContext,
 } from '@datadog/browser-rum-core'
 
-export { DEFAULT_TRACKED_RESOURCE_HEADERS } from '@datadog/browser-rum-core'
+export { DEFAULT_TRACKED_RESOURCE_HEADERS, CanvasRecordingQuality } from '@datadog/browser-rum-core'
 
 const recorderApi = makeRecorderApi()
 


### PR DESCRIPTION
## Motivation

The experimental canvas recording feature (`sessionReplayCanvasRecording`) exposed raw numeric knobs (`maxFramesPerSecond`, `hashingMaxDimension`, `maxImageDimension`) that are hard for customers to reason about, and frame rate/quality defaults were more conservative than what other platforms offer for canvas replay. This is a step towards a customer-friendly, production-ready config surface, while it's still gated behind an experimental flag.

## Changes

- Replaced the raw `sessionReplayCanvasRecording` knobs with a single `quality` option (`low` / `medium` / `high`), each preset internally mapping to a full bundle of capture rate, hashing/image dimensions, and encode quality.
- Raised the effective max capture rate ceiling (up to 8 fps on `high`), bringing us more in line with what other platforms offer for canvas recording.
- Switched captured canvas frame encoding from PNG to WebP, which produces significantly smaller payloads for the same visual fidelity while still supporting the alpha channel (unlike JPEG).
- Extracted a shared `createDownscaledCanvas` helper used by both the snapshot and hashing paths, removing duplicated canvas-downscaling logic.

This only affects the `@hidden`, experimental `sessionReplayCanvasRecording` option, so no deprecation/migration path is needed.

## Test instructions

- `yarn typecheck`
- `yarn test:unit --spec packages/browser-rum-core/src/domain/configuration/configuration.spec.ts`
- `yarn test:unit --spec packages/browser-rum/src/domain/record/canvas/canvasSnapshot.spec.ts`
- `yarn test:unit --spec packages/browser-rum/src/domain/record/trackers/trackCanvasCapture.spec.ts`
- `yarn test:unit --spec packages/browser-rum/src/domain/record/trackers/trackCanvasContent.spec.ts`
- `yarn test:unit --spec packages/browser-rum/src/domain/record/record.spec.ts`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file