### PR TITLE
✅ Stabilize base plugin error E2E tests in WebKit

### DIFF
--- a/test/e2e/scenario/plugins/basePluginErrorTests.ts
+++ b/test/e2e/scenario/plugins/basePluginErrorTests.ts
@@ -22,13 +22,16 @@ export function runBasePluginErrorTests(configs: ErrorPluginTestConfig[]) {
     test.describe(`base plugin: ${name}`, () => {
       test.describe('errors', () => {
         loadApp(createTest('should report client-side error').withRum()).run(
-          async ({ page, flushEvents, intakeRegistry, withBrowserLogs }) => {
+          async ({ page, flushEvents, intakeRegistry, withBrowserLogs, browserName }) => {
             await page.click('text=Go to Error Test')
             await page.waitForURL(`**${viewPrefix}/error-test`)
 
             await page.click('[data-testid="trigger-error"]')
             await page.waitForSelector('[data-testid="error-handled"]')
 
+            if (browserName === 'webkit') {
+              await page.evaluate(() => window.dispatchEvent(new Event('beforeunload')))
+            }
             await flushEvents()
 
             const customErrors = intakeRegistry.rumErrorEvents.filter((e) => e.error.source === 'custom')


### PR DESCRIPTION
## Summary
- Follow-up to #5037: in WebKit, `beforeunload` isn't reliably fired during the `basePluginErrorTests` E2E scenario, so errors aren't flushed before assertions run.
- Manually dispatch the `beforeunload` event when `browserName === 'webkit'` before calling `flushEvents`.

## Test plan
- [ ] `yarn test:e2e -g "base plugin"` passes reliably on WebKit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)